### PR TITLE
Prevent crash when ConversationModel::fetchMore is called too early

### DIFF
--- a/src/conversationmodel.cpp
+++ b/src/conversationmodel.cpp
@@ -336,6 +336,9 @@ void ConversationModel::fetchMore(const QModelIndex &parent)
     Q_UNUSED(parent);
     Q_D(ConversationModel);
 
+    if (!d->isModelReady() || d->eventRootItem->childCount() < 1)
+        return;
+
     EventsQuery query = d->buildQuery();
 
     Event &event = d->eventRootItem->eventAt(d->eventRootItem->childCount() - 1);

--- a/src/eventtreeitem.cpp
+++ b/src/eventtreeitem.cpp
@@ -79,6 +79,7 @@ EventTreeItem *EventTreeItem::child(int row)
 
 Event &EventTreeItem::eventAt(int row)
 {
+    Q_ASSERT(row >= 0 && row < children.count());
     return children.value(row)->event();
 }
 


### PR DESCRIPTION
When called before the model data is ready, this would crash under
EventTreeItem::eventAt.
