### PR TITLE
Add declarative plugin

### DIFF
--- a/declarative/declarative.pro
+++ b/declarative/declarative.pro
@@ -1,0 +1,26 @@
+include( ../common-project-config.pri )
+include( ../common-vars.pri )
+
+TARGET = commhistory-declarative
+PLUGIN_IMPORT_PATH = org/nemomobile/commhistory
+VERSION = $$PROJECT_VERSION
+
+LIBS += -L../src \
+    ../src/libcommhistory.so
+INCLUDEPATH += ../src 
+
+SOURCES += src/plugin.cpp
+
+HEADERS += src/constants.h
+
+# do not edit below here, move this to a shared .pri?
+TEMPLATE = lib
+CONFIG += qt plugin hide_symbols
+QT += declarative
+
+target.path = $$[QT_INSTALL_IMPORTS]/$$PLUGIN_IMPORT_PATH
+INSTALLS += target
+
+qmldir.files += $$PWD/qmldir
+qmldir.path +=  $$[QT_INSTALL_IMPORTS]/$$$$PLUGIN_IMPORT_PATH
+INSTALLS += qmldir

--- a/declarative/qmldir
+++ b/declarative/qmldir
@@ -1,0 +1,1 @@
+plugin commhistory-declarative

--- a/declarative/src/constants.h
+++ b/declarative/src/constants.h
@@ -1,0 +1,85 @@
+/* Copyright (C) 2012 John Brooks <john.brooks@dereferenced.net>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#ifndef COMMHISTORYCONSTANTS_H
+#define COMMHISTORYCONSTANTS_H
+
+#include <QObject>
+
+/* Class for exposing constants and enums from libcommhistory to QML.
+ * Not instantiable. */
+class CommHistoryConstants : public QObject
+{
+    Q_OBJECT
+    Q_ENUMS(EventType EventDirection EventStatus EventReadStatus ChatType)
+
+public:
+    enum EventType {
+        UnknownType = 0,
+        IMEvent,
+        SMSEvent,
+        CallEvent,
+        VoicemailEvent,
+        StatusMessageEvent,
+        MMSEvent,
+        ClassZeroSMSEvent
+    };
+
+    enum EventDirection {
+        UnknownDirection = 0,
+        Inbound,
+        Outbound
+    };
+
+    enum EventStatus {
+        UnknownStatus = 0,
+        SendingStatus,
+        SentStatus,
+        DeliveredStatus,
+        FailedStatus,
+        TemporarilyFailedStatus = FailedStatus,
+        PermanentlyFailedStatus
+    };
+
+    enum EventReadStatus {
+        UnknownReadStatus = 0,
+        ReadStatusRead,
+        ReadStatusDeleted
+    };
+
+    enum ChatType {
+        ChatTypeP2P = 0,
+        ChatTypeUnnamed,
+        ChatTypeRoom
+    };
+};
+
+#endif
+

--- a/declarative/src/plugin.cpp
+++ b/declarative/src/plugin.cpp
@@ -1,0 +1,64 @@
+/* Copyright (C) 2012 John Brooks <john.brooks@dereferenced.net>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include <QtGlobal>
+#include <QtDeclarative>
+#include <QDeclarativeEngine>
+#include <QDeclarativeExtensionPlugin>
+#include "constants.h"
+#include "eventmodel.h"
+#include "groupmodel.h"
+#include "conversationmodel.h"
+
+class Q_DECL_EXPORT CommHistoryPlugin : public QDeclarativeExtensionPlugin
+{
+public:
+    virtual ~CommHistoryPlugin() { }
+
+    void initializeEngine(QDeclarativeEngine *engine, const char *uri)
+    {
+        Q_ASSERT(uri == QLatin1String("org.nemomobile.commhistory"));
+        Q_UNUSED(uri);
+        Q_UNUSED(engine);
+    }
+
+    void registerTypes(const char *uri)
+    {
+        Q_ASSERT(uri == QLatin1String("org.nemomobile.commhistory"));
+
+        qmlRegisterUncreatableType<CommHistoryConstants>(uri, 1, 0, "CommHistory", "Constants-only type");
+        qmlRegisterType<CommHistory::EventModel>(uri, 1, 0, "CommEventModel");
+        qmlRegisterType<CommHistory::GroupModel>(uri, 1, 0, "CommGroupModel");
+        qmlRegisterType<CommHistory::ConversationModel>(uri, 1, 0, "CommConversationModel");
+    }
+};
+
+Q_EXPORT_PLUGIN2(commhistoryplugin, CommHistoryPlugin);
+

--- a/libcommhistory.pro
+++ b/libcommhistory.pro
@@ -25,6 +25,7 @@
 TEMPLATE  = subdirs
 CONFIG   += ordered
 SUBDIRS   = src   \
+            declarative \
             tools \
             tests
 


### PR DESCRIPTION
At the moment, this plugin just exposes the three common models, and
a special class with important constants and enums. More functionality
can be added later.

PR #2 makes the models expose the necessary roles to be used from QML.
