### PR TITLE
Update GroupObject data on rowsMoved/layoutChanged

### DIFF
--- a/declarative/src/groupproxymodel.cpp
+++ b/declarative/src/groupproxymodel.cpp
@@ -59,6 +59,9 @@ void GroupProxyModel::setSourceModel(QAbstractItemModel *m)
 
     connect(model, SIGNAL(dataChanged(QModelIndex,QModelIndex)),
             SLOT(sourceDataChanged(QModelIndex,QModelIndex)));
+    connect(model, SIGNAL(rowsMoved(QModelIndex,int,int,QModelIndex,int)),
+            SLOT(sourceRowsMoved()));
+    connect(model, SIGNAL(layoutChanged()), SLOT(sourceRowsMoved()));
     connect(model, SIGNAL(rowsAboutToBeRemoved(QModelIndex,int,int)),
             SLOT(sourceRowsRemoved(QModelIndex,int,int)));
 
@@ -122,6 +125,11 @@ void GroupProxyModel::sourceDataChanged(const QModelIndex &topLeft, const QModel
 
         obj->updateGroup(g);
     }
+}
+
+void GroupProxyModel::sourceRowsMoved()
+{
+    sourceDataChanged(model->index(0, 0), model->index(model->rowCount()-1, model->columnCount()-1));
 }
 
 void GroupProxyModel::sourceRowsRemoved(const QModelIndex &parent, int start, int end)

--- a/declarative/src/groupproxymodel.h
+++ b/declarative/src/groupproxymodel.h
@@ -65,6 +65,7 @@ signals:
 private slots:
     void sourceDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
     void sourceRowsRemoved(const QModelIndex &parent, int start, int end);
+    void sourceRowsMoved();
 
 private:
     CommHistory::GroupModel *model;


### PR DESCRIPTION
CommHistory::GroupModel does not send dataChanged signals when rows
are moved, which could result in GroupObject having stale data.
