### PR TITLE
Remove uses of a non-existent internal signal

### DIFF
--- a/src/callmodel.cpp
+++ b/src/callmodel.cpp
@@ -235,14 +235,6 @@ void CallModelPrivate::modelUpdatedSlot( bool successful )
     EventModelPrivate::modelUpdatedSlot(successful);
     countedUids.clear();
     updatedGroups.clear();
-
-    if (contactChangesEnabled && contactListener) {
-        connect(contactListener.data(),
-                SIGNAL(contactSettingsChanged(const QHash<QString, QVariant> &)),
-                this,
-                SLOT(contactSettingsChangedSlot(const QHash<QString, QVariant> &)),
-                Qt::UniqueConnection);
-    }
 }
 
 bool CallModelPrivate::belongToSameGroup( const Event &e1, const Event &e2 )
@@ -885,15 +877,6 @@ void CallModelPrivate::slotAllCallsDeleted(int unused)
     q->beginResetModel();
     clearEvents();
     q->endResetModel();
-}
-
-void CallModelPrivate::contactSettingsChangedSlot(const QHash<QString, QVariant> &changedSettings)
-{
-    Q_UNUSED(changedSettings);
-    Q_Q(CallModel);
-
-    if (hasBeenFetched)
-        q->getEvents();
 }
 
 /* ************************************************************************** *

--- a/src/callmodel_p.h
+++ b/src/callmodel_p.h
@@ -87,7 +87,6 @@ public:
 public Q_SLOTS:
     void slotAllCallsDeleted(int unused);
     void doDeleteCallGroup(QSparqlResult *result);
-    void contactSettingsChangedSlot(const QHash<QString, QVariant> &changedSettings);
 
 public:
     CallModel::Sorting sortBy;

--- a/src/conversationmodel.cpp
+++ b/src/conversationmodel.cpp
@@ -233,14 +233,6 @@ void ConversationModelPrivate::modelUpdatedSlot(bool successful)
     } else{
         EventModelPrivate::modelUpdatedSlot(successful);
     }
-
-    if (contactChangesEnabled && contactListener) {
-        connect(contactListener.data(),
-                SIGNAL(contactSettingsChanged(const QHash<QString, QVariant> &)),
-                this,
-                SLOT(contactSettingsChangedSlot(const QHash<QString, QVariant> &)),
-                Qt::UniqueConnection);
-    }
 }
 
 void ConversationModelPrivate::extraReceivedSlot(QList<CommHistory::Event> events,
@@ -259,15 +251,6 @@ bool ConversationModelPrivate::isModelReady() const
 {
     return activeQueries == 0
            && eventsFilled < (firstFetch ? firstChunkSize : chunkSize);
-}
-
-void ConversationModelPrivate::contactSettingsChangedSlot(const QHash<QString, QVariant> &changedSettings)
-{
-    Q_UNUSED(changedSettings);
-    Q_Q(ConversationModel);
-
-    if (!filterGroupIds.isEmpty())
-        q->getEvents(filterGroupIds.toList());
 }
 
 ConversationModel::ConversationModel(QObject *parent)

--- a/src/conversationmodel_p.h
+++ b/src/conversationmodel_p.h
@@ -51,7 +51,6 @@ public Q_SLOTS:
     virtual void modelUpdatedSlot(bool successful);
     void extraReceivedSlot(QList<CommHistory::Event> events, QVariantList extra);
     void groupsDeletedSlot(const QList<int> &groupIds);
-    void contactSettingsChangedSlot(const QHash<QString, QVariant> &changedSettings);
 
 public:
     QSet<int> filterGroupIds;

--- a/src/groupmanager.cpp
+++ b/src/groupmanager.cpp
@@ -501,15 +501,6 @@ void GroupManagerPrivate::slotContactRemoved(quint32 localId)
     }
 }
 
-void GroupManagerPrivate::slotContactSettingsChanged(const QHash<QString, QVariant> &changedSettings)
-{
-    Q_UNUSED(changedSettings);
-    Q_Q(GroupManager);
-
-    if (!groups.isEmpty())
-        q->getGroups(filterLocalUid, filterRemoteUid);
-}
-
 void GroupManagerPrivate::startContactListening()
 {
     if (contactChangesEnabled && !contactListener) {
@@ -522,11 +513,6 @@ void GroupManagerPrivate::startContactListening()
                 SIGNAL(contactRemoved(quint32)),
                 this,
                 SLOT(slotContactRemoved(quint32)));
-
-        connect(contactListener.data(),
-                SIGNAL(contactSettingsChanged(const QHash<QString, QVariant> &)),
-                this,
-                SLOT(slotContactSettingsChanged(const QHash<QString, QVariant> &)));
     }
 }
 

--- a/src/groupmanager_p.h
+++ b/src/groupmanager_p.h
@@ -90,8 +90,6 @@ public Q_SLOTS:
 
     void slotContactRemoved(quint32 localId);
 
-    void slotContactSettingsChanged(const QHash<QString, QVariant> &changedSettings);
-
 public:
     EventModel::QueryMode queryMode;
     int chunkSize;


### PR DESCRIPTION
This was leftover from the removal of libqtcontacts-tracker-extensions.
When we have contact settings later, we'll be able to use a smarter
method of reacting to changes (than just reloading everything).
