### PR TITLE
[libcommhistory] Force the contacts backend selection in qt5

### DIFF
--- a/rpm/libcommhistory-qt5.spec
+++ b/rpm/libcommhistory-qt5.spec
@@ -1,6 +1,6 @@
 Name:       libcommhistory-qt5
 Summary:    Communications event history database API
-Version:    1.5.2
+Version:    1.5.7
 Release:    1
 Group:      System/Libraries
 License:    LGPL

--- a/rpm/libcommhistory.spec
+++ b/rpm/libcommhistory.spec
@@ -1,6 +1,6 @@
 Name:       libcommhistory
 Summary:    Communications event history database API
-Version:    1.5.6
+Version:    1.5.7
 Release:    1
 Group:      System/Libraries
 License:    LGPL

--- a/src/contactlistener.cpp
+++ b/src/contactlistener.cpp
@@ -140,7 +140,12 @@ void ContactListener::init()
     qDebug() << Q_FUNC_INFO;
 
     if (!m_ContactManager) {
+#ifdef USING_QTPIM
+        // Temporary override until qtpim supports QTCONTACTS_MANAGER_OVERRIDE
+        QString envspec(QStringLiteral("org.nemomobile.contacts.sqlite"));
+#else
         QString envspec(QLatin1String(qgetenv("NEMO_CONTACT_MANAGER")));
+#endif
         if (!envspec.isEmpty()) {
             qDebug() << "Using contact manager:" << envspec;
             m_ContactManager = new QContactManager(envspec);

--- a/src/queryresult.cpp
+++ b/src/queryresult.cpp
@@ -98,7 +98,12 @@ QString getAddresbookNameOrder()
 
 QContactManager *createManager()
 {
+#ifdef USING_QTPIM
+    // Temporary override until qtpim supports QTCONTACTS_MANAGER_OVERRIDE
+    QString envspec(QStringLiteral("org.nemomobile.contacts.sqlite"));
+#else
     QString envspec(QLatin1String(qgetenv("NEMO_CONTACT_MANAGER")));
+#endif
     if (!envspec.isEmpty()) {
         qDebug() << "Using contact manager:" << envspec;
         return new QContactManager(envspec);

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -68,7 +68,12 @@ static int contactNumber = 0;
 
 QContactManager *createManager()
 {
+#ifdef USING_QTPIM
+    // Temporary override until qtpim supports QTCONTACTS_MANAGER_OVERRIDE
+    QString envspec(QStringLiteral("org.nemomobile.contacts.sqlite"));
+#else
     QString envspec(QLatin1String(qgetenv("NEMO_CONTACT_MANAGER")));
+#endif
     if (!envspec.isEmpty()) {
         qDebug() << "Using contact manager:" << envspec;
         return new QContactManager(envspec);


### PR DESCRIPTION
qtpim does not yet support the QTCONTACTS_MANAGER_OVERRIDE mechanism
for selecting the default contacts backend.
