### PR TITLE
[libcommhistory] Change declarative API to not use QObjectList

### DIFF
--- a/src/contactgroup.cpp
+++ b/src/contactgroup.cpp
@@ -304,10 +304,10 @@ QList<GroupObject*> ContactGroup::groups() const
     return d->groups;
 }
 
-QObjectList ContactGroup::groupObjects() const
+QList<QObject*> ContactGroup::groupObjects() const
 {
     Q_D(const ContactGroup);
-    QObjectList l;
+    QList<QObject*> l;
     l.reserve(d->groups.size());
     foreach (GroupObject *o, d->groups)
         l.append(o);

--- a/src/contactgroup.h
+++ b/src/contactgroup.h
@@ -85,9 +85,9 @@ public:
     Q_PROPERTY(QDateTime lastModified READ lastModified NOTIFY lastModifiedChanged);
     QDateTime lastModified() const;
  
-    Q_PROPERTY(QObjectList groups READ groupObjects NOTIFY groupsChanged);
+    Q_PROPERTY(QList<QObject*> groups READ groupObjects NOTIFY groupsChanged);
     QList<GroupObject*> groups() const;
-    QObjectList groupObjects() const;
+    QList<QObject*> groupObjects() const;
 
     // Does not work for multi-target groups
     Q_INVOKABLE CommHistory::GroupObject *findGroup(const QString &localUid, const QString &remoteUid);

--- a/src/contactgroupmodel.cpp
+++ b/src/contactgroupmodel.cpp
@@ -23,14 +23,15 @@
 #include <QtDBus/QtDBus>
 #include <QDebug>
 #include <QStringList>
-#include <QObjectList>
 
 #include "contactgroupmodel.h"
 #include "contactgroupmodel_p.h"
 #include "groupmanager.h"
 #include "contactgroup.h"
 
-Q_DECLARE_METATYPE(QObjectList)
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+Q_DECLARE_METATYPE(QList<QObject*>)
+#endif
 
 using namespace CommHistory;
 
@@ -362,7 +363,7 @@ QVariant ContactGroupModel::data(const QModelIndex &index, int role) const
             var = QVariant::fromValue<QStringList>(g->contactNames());
             break;
         case Groups:
-            var = QVariant::fromValue<QObjectList>(g->groupObjects());
+            var = QVariant::fromValue<QList<QObject*> >(g->groupObjects());
             break;
         case EndTime:
             var = g->endTime();
@@ -416,9 +417,9 @@ ContactGroup *ContactGroupModel::at(const QModelIndex &index) const
     return d->items.value(index.row());
 }
 
-QObjectList ContactGroupModel::contactGroups() const
+QList<QObject*> ContactGroupModel::contactGroups() const
 {
-    QObjectList re;
+    QList<QObject*> re;
     re.reserve(d->items.size());
 
     foreach (ContactGroup *g, d->items)

--- a/src/contactgroupmodel.h
+++ b/src/contactgroupmodel.h
@@ -110,8 +110,8 @@ public:
     /*!
      * List of contact groups in the model
      */
-    Q_PROPERTY(QObjectList contactGroups READ contactGroups)
-    QObjectList contactGroups() const;
+    Q_PROPERTY(QList<QObject*> contactGroups READ contactGroups)
+    QList<QObject*> contactGroups() const;
 
     /* reimp */
     virtual bool canFetchMore(const QModelIndex &parent) const;


### PR DESCRIPTION
QObjectList is causing problems with QtQuick2, despite type registration. QList<QObject*> behaves correctly on both Qt4 and Qt5.
