### PR TITLE
[libcommhistory] Fix random EventsQuery failures caused by QHash randomization

### DIFF
--- a/src/eventsquery.cpp
+++ b/src/eventsquery.cpp
@@ -22,6 +22,7 @@
 
 #include <QDebug>
 #include <QStringList>
+#include <algorithm>
 
 #include "eventsquery.h"
 
@@ -400,6 +401,7 @@ public:
         }
 
         variables = finalProperties.toList();
+        std::sort(variables.begin(), variables.end());
     }
 
     EventsQuery *q;


### PR DESCRIPTION
The randomized order of QHash in Qt5 could order events properties in a
way that caused invalid queries.
