### PR TITLE
[libcommhistory] Make EventModel::deleteEvent(int id) invokable by QML

### DIFF
--- a/src/eventmodel.h
+++ b/src/eventmodel.h
@@ -262,7 +262,7 @@ public:
      * \param id id of the event to be deleted.
      * \return true if successful
      */
-    virtual bool deleteEvent(int id);
+    Q_INVOKABLE virtual bool deleteEvent(int id);
 
     /*!
      * Delete an event from the model and the database.


### PR DESCRIPTION
I thought I'd try a smaller pull request this time.
