### PR TITLE
[libcommhistory] Suppress contacts without the required address type

### DIFF
--- a/src/contactlistener.h
+++ b/src/contactlistener.h
@@ -66,6 +66,30 @@ class LIBCOMMHISTORY_EXPORT ContactListener : public QObject
     Q_OBJECT
 
 public:
+    enum ContactAddressType {
+        UnknownType = 0,
+        IMAccountType,
+        PhoneNumberType,
+        EmailAddressType
+    };
+
+    struct ContactAddress {
+        QString localUid;
+        QString remoteUid;
+        ContactAddressType type;
+
+        QPair<QString, QString> uidPair() const { return qMakePair(localUid, remoteUid); }
+    };
+
+    template<typename T1, typename T2, typename T3>
+    ContactAddress makeContactAddress(T1 localUid, T2 remoteUid, T3 type) {
+        ContactAddress addr;
+        addr.localUid = localUid;
+        addr.remoteUid = remoteUid;
+        addr.type = type;
+        return addr;
+    }
+
     /*!
      *  \returns Contact listener
      */
@@ -76,6 +100,9 @@ public:
     static bool addressMatchesList(const QString &localUid,
                                    const QString &remoteUid,
                                    const QList< QPair<QString,QString> > &contactAddresses);
+    static bool addressMatchesList(const QString &localUid,
+                                   const QString &remoteUid,
+                                   const QList<ContactAddress> &contactAddresses);
 
     static int internalContactId(const QContactIdType &id);
     static int internalContactId(const QContact &contact);
@@ -101,7 +128,7 @@ public:
 Q_SIGNALS:
     void contactUpdated(quint32 localId,
                         const QString &contactName,
-                        const QList< QPair<QString,QString> > &contactAddresses);
+                        const QList<ContactAddress> &contactAddresses);
     void contactRemoved(quint32 localId);
     void contactUnknown(const QPair<QString, QString> &address);
 

--- a/src/eventmodel_p.h
+++ b/src/eventmodel_p.h
@@ -33,12 +33,12 @@
 #include "eventtreeitem.h"
 #include "databaseio.h"
 #include "libcommhistoryexport.h"
+#include "contactlistener.h"
 
 class QSqlQuery;
 
 namespace CommHistory {
 
-class ContactListener;
 class UpdatesEmitter;
 
 /*!
@@ -58,6 +58,8 @@ class LIBCOMMHISTORY_EXPORT EventModelPrivate : public QObject
     } ContactChangeType;
 
 public:
+    typedef ContactListener::ContactAddress ContactAddress;
+
     EventModel *q_ptr;
 
     EventModelPrivate(EventModel *model = 0);
@@ -147,6 +149,8 @@ public:
     bool setContactFromCache(CommHistory::Event &event);
     void startContactListening();
 
+    bool contactHasAddressType(ContactListener::ContactAddressType type, quint32 contactId) const;
+
     // This is the root node for the internal event tree. In a standard
     // flat model, eventRootNode has rowCount() children with events.
     // Use this in fillModel() and other methods if you're implementing
@@ -171,6 +175,10 @@ public:
     // (local id, remote id) -> (contact id, name)
     QMap<QPair<QString,QString>, QList<Event::Contact> > contactCache;
 
+    QSet<quint32> phoneContacts;
+    QSet<quint32> imContacts;
+    QSet<quint32> emailContacts;
+
     QThread *bgThread;
 
     QSharedPointer<UpdatesEmitter> emitter;
@@ -194,7 +202,7 @@ public Q_SLOTS:
 
     virtual void slotContactUpdated(quint32 localId,
                                     const QString &contactName,
-                                    const QList< QPair<QString,QString> > &contactAddresses);
+                                    const QList<ContactAddress> &contactAddresses);
 
     virtual void slotContactRemoved(quint32 localId);
 

--- a/src/groupmanager.cpp
+++ b/src/groupmanager.cpp
@@ -42,6 +42,7 @@ static const int defaultChunkSize = 50;
 }
 
 using namespace CommHistory;
+typedef ContactListener::ContactAddress ContactAddress;
 
 GroupManagerPrivate::GroupManagerPrivate(GroupManager *manager)
         : q_ptr(manager)
@@ -302,7 +303,7 @@ DatabaseIO* GroupManagerPrivate::database()
 
 void GroupManagerPrivate::slotContactUpdated(quint32 localId,
                                            const QString &contactName,
-                                           const QList< QPair<QString,QString> > &contactAddresses)
+                                           const QList<ContactAddress> &contactAddresses)
 {
     Q_Q(GroupManager);
 
@@ -398,7 +399,7 @@ void GroupManagerPrivate::startContactListening()
         connect(contactListener.data(),
                 SIGNAL(contactUpdated(quint32, const QString&, const QList<QPair<QString,QString> >&)),
                 this,
-                SLOT(slotContactUpdated(quint32, const QString&, const QList<QPair<QString,QString> >&)));
+                SLOT(slotContactUpdated(quint32, const QString&, const QList<ContactAddress>&)));
         connect(contactListener.data(),
                 SIGNAL(contactRemoved(quint32)),
                 this,

--- a/src/groupmanager_p.h
+++ b/src/groupmanager_p.h
@@ -30,6 +30,7 @@
 #include "groupmanager.h"
 #include "eventmodel.h"
 #include "group.h"
+#include "contactlistener.h"
 
 namespace CommHistory {
 
@@ -73,7 +74,7 @@ public Q_SLOTS:
 
     void slotContactUpdated(quint32 localId,
                             const QString &contactName,
-                            const QList< QPair<QString,QString> > &contactAddresses);
+                            const QList<ContactListener::ContactAddress> &contactAddresses);
 
     void slotContactRemoved(quint32 localId);
 

--- a/src/recentcontactsmodel.h
+++ b/src/recentcontactsmodel.h
@@ -39,6 +39,8 @@ class LIBCOMMHISTORY_EXPORT RecentContactsModel : public EventModel
 {
     Q_OBJECT
 
+    Q_PROPERTY(QString selectionProperty READ selectionProperty WRITE setSelectionProperty)
+
 public:
     /*!
      * Model constructor.
@@ -58,6 +60,27 @@ public:
      * \return true if successful, otherwise false
      */
     Q_INVOKABLE bool getEvents();
+
+    /*!
+     * Return the name of the property type that contacts must possess to be included in the model.
+     *
+     * \return Property type name
+     */
+    QString selectionProperty() const;
+
+    /*!
+     * Set the property type that contacts must possess to be included in the model.
+     *
+     * Valid values are: [ 'accountUri' - contacts must possess an IM account,
+     *                     'phoneNumber' - contacts must possess a phone number,
+     *                     'emailAddress' - contacts must possess an email address ]
+     *
+     * The property names correspond to the property names by which these attributes
+     * are exposed in 'org.nemomobile.contacts.Person'.
+     *
+     * \param name Property type name
+     */
+    void setSelectionProperty(const QString &name);
 
 private:
     Q_DECLARE_PRIVATE(RecentContactsModel);

--- a/tests/ut_recentcontactsmodel/recentcontactsmodeltest.cpp
+++ b/tests/ut_recentcontactsmodel/recentcontactsmodeltest.cpp
@@ -302,6 +302,117 @@ void RecentContactsModelTest::differentTypes()
     QCOMPARE(e.remoteUid(), alicePhone2);
 }
 
+void RecentContactsModelTest::selectionProperty()
+{
+    RecentContactsModel phoneModel;
+    phoneModel.setSelectionProperty(QString::fromLatin1("phoneNumber"));
+
+    RecentContactsModel imModel;
+    imModel.setSelectionProperty(QString::fromLatin1("accountUri"));
+
+    RecentContactsModel emailModel;
+    emailModel.setSelectionProperty(QString::fromLatin1("emailAddress"));
+
+    QVERIFY(phoneModel.getEvents());
+    QVERIFY(imModel.getEvents());
+    QVERIFY(emailModel.getEvents());
+
+    QCOMPARE(phoneModel.rowCount(), 0);
+    QCOMPARE(imModel.rowCount(), 0);
+    QCOMPARE(emailModel.rowCount(), 0);
+
+    for (int count = 1; count <= 7; ++count) {
+        addEvents(count, count);
+        QTest::qWait(10000);
+    }
+
+    // Two contacts have phone numbers, two have IM addresses, none have email
+    QCOMPARE(phoneModel.rowCount(), 2);
+    QCOMPARE(imModel.rowCount(), 2);
+    QCOMPARE(emailModel.rowCount(), 0);
+
+    Event e;
+
+    // Phone contacts (not events)
+    e = phoneModel.event(phoneModel.index(0, 0));
+    QCOMPARE(e.contacts(), QList<ContactDetails>() << qMakePair(bobId, bobName));
+    QCOMPARE(e.type(), Event::IMEvent);
+    QCOMPARE(e.direction(), Event::Outbound);
+    QCOMPARE(e.localUid(), bobIm.first);
+    QCOMPARE(e.remoteUid(), bobIm.second);
+
+    e = phoneModel.event(phoneModel.index(1, 0));
+    QCOMPARE(e.contacts(), QList<ContactDetails>() << qMakePair(aliceId, aliceName));
+    QCOMPARE(e.type(), Event::SMSEvent);
+    QCOMPARE(e.direction(), Event::Outbound);
+    QCOMPARE(e.localUid(), phoneAccount);
+    QCOMPARE(e.remoteUid(), alicePhone2);
+
+    // IM contacts
+    e = imModel.event(imModel.index(0, 0));
+    QCOMPARE(e.contacts(), QList<ContactDetails>() << qMakePair(bobId, bobName));
+    QCOMPARE(e.type(), Event::IMEvent);
+    QCOMPARE(e.direction(), Event::Outbound);
+    QCOMPARE(e.localUid(), bobIm.first);
+    QCOMPARE(e.remoteUid(), bobIm.second);
+
+    e = imModel.event(imModel.index(1, 0));
+    QCOMPARE(e.contacts(), QList<ContactDetails>() << qMakePair(charlieId, charlieName));
+    QCOMPARE(e.type(), Event::IMEvent);
+    QCOMPARE(e.direction(), Event::Outbound);
+    QCOMPARE(e.localUid(), charlieIm2.first);
+    QCOMPARE(e.remoteUid(), charlieIm2.second);
+
+    {
+        // Repeat the tests to test filtering on fill
+        RecentContactsModel phoneModel;
+        phoneModel.setSelectionProperty(QString::fromLatin1("phoneNumber"));
+
+        RecentContactsModel imModel;
+        imModel.setSelectionProperty(QString::fromLatin1("accountUri"));
+
+        RecentContactsModel emailModel;
+        emailModel.setSelectionProperty(QString::fromLatin1("emailAddress"));
+
+        QVERIFY(phoneModel.getEvents());
+        QVERIFY(imModel.getEvents());
+        QVERIFY(emailModel.getEvents());
+
+        QTRY_COMPARE(phoneModel.rowCount(), 2);
+        QTRY_COMPARE(imModel.rowCount(), 2);
+        QCOMPARE(emailModel.rowCount(), 0);
+
+        // Results should be indentical
+        e = phoneModel.event(phoneModel.index(0, 0));
+        QCOMPARE(e.contacts(), QList<ContactDetails>() << qMakePair(bobId, bobName));
+        QCOMPARE(e.type(), Event::IMEvent);
+        QCOMPARE(e.direction(), Event::Outbound);
+        QCOMPARE(e.localUid(), bobIm.first);
+        QCOMPARE(e.remoteUid(), bobIm.second);
+
+        e = phoneModel.event(phoneModel.index(1, 0));
+        QCOMPARE(e.contacts(), QList<ContactDetails>() << qMakePair(aliceId, aliceName));
+        QCOMPARE(e.type(), Event::SMSEvent);
+        QCOMPARE(e.direction(), Event::Outbound);
+        QCOMPARE(e.localUid(), phoneAccount);
+        QCOMPARE(e.remoteUid(), alicePhone2);
+
+        e = imModel.event(imModel.index(0, 0));
+        QCOMPARE(e.contacts(), QList<ContactDetails>() << qMakePair(bobId, bobName));
+        QCOMPARE(e.type(), Event::IMEvent);
+        QCOMPARE(e.direction(), Event::Outbound);
+        QCOMPARE(e.localUid(), bobIm.first);
+        QCOMPARE(e.remoteUid(), bobIm.second);
+
+        e = imModel.event(imModel.index(1, 0));
+        QCOMPARE(e.contacts(), QList<ContactDetails>() << qMakePair(charlieId, charlieName));
+        QCOMPARE(e.type(), Event::IMEvent);
+        QCOMPARE(e.direction(), Event::Outbound);
+        QCOMPARE(e.localUid(), charlieIm2.first);
+        QCOMPARE(e.remoteUid(), charlieIm2.second);
+    }
+}
+
 void RecentContactsModelTest::cleanup()
 {
     cleanupTestEvents();

--- a/tests/ut_recentcontactsmodel/recentcontactsmodeltest.h
+++ b/tests/ut_recentcontactsmodel/recentcontactsmodeltest.h
@@ -16,6 +16,7 @@ private slots:
     void repeated();
     void limitedDynamic();
     void differentTypes();
+    void selectionProperty();
 
     void cleanup();
     void cleanupTestCase();


### PR DESCRIPTION
When selecting recent contacts for IM, we only want contacts that have IM accounts.
