### PR TITLE
[libcommhistory] Add setEventStatus method to DeclarativeGroupManager

### DIFF
--- a/declarative/src/declarativegroupmanager.cpp
+++ b/declarative/src/declarativegroupmanager.cpp
@@ -31,6 +31,7 @@
 
 #include "declarativegroupmanager.h"
 #include "sharedbackgroundthread.h"
+#include "singleeventmodel.h"
 #include <QTimer>
 
 using namespace CommHistory;
@@ -111,5 +112,21 @@ int DeclarativeGroupManager::createOutgoingMessageEvent(int groupId, const QStri
 
     qWarning() << Q_FUNC_INFO << "Failed creating event";
     return -1;
+}
+
+bool DeclarativeGroupManager::setEventStatus(int eventId, int status)
+{
+    SingleEventModel model;
+    if (!model.getEventById(eventId)) {
+        qWarning() << Q_FUNC_INFO << "No event with id" << eventId;
+        return false;
+    }
+
+    Event ev = model.event(model.index(0, 0));
+    if (ev.status() == status)
+        return true;
+
+    ev.setStatus(static_cast<Event::EventStatus>(status));
+    return model.modifyEvent(ev);
 }
 

--- a/declarative/src/declarativegroupmanager.h
+++ b/declarative/src/declarativegroupmanager.h
@@ -56,6 +56,8 @@ public:
      * inline if necessary. */
     Q_INVOKABLE int createOutgoingMessageEvent(int groupId, const QString &localUid, const QString &remoteUid, const QString &text);
 
+    Q_INVOKABLE bool setEventStatus(int eventId, int status);
+
 public slots:
     void reload();
 


### PR DESCRIPTION
Technically, this has nothing to do with groups. Regardless, there is no
other sane place to put this with the current API, and it makes no sense
to create a more elaborate event API for the current scope of the
declarative plugin.

It couldn't be reliably done as part of the ConversationModel without
also having use of SingleEventModel as a fallback, and that would be
much less convenient for usage.
