### PR TITLE
[libcommhistory] Switch to requiredProperty instead of selectionProperty...

### DIFF
--- a/src/eventmodel_p.cpp
+++ b/src/eventmodel_p.cpp
@@ -35,6 +35,7 @@
 #include "constants.h"
 #include "commonutils.h"
 #include "debug.h"
+#include "recentcontactsmodel.h"
 
 using namespace CommHistory;
 
@@ -607,11 +608,14 @@ void EventModelPrivate::startContactListening()
     }
 }
 
-bool EventModelPrivate::contactHasAddressType(ContactListener::ContactAddressType type, quint32 localId) const
+bool EventModelPrivate::contactHasAddress(int types, quint32 localId) const
 {
-    Q_ASSERT((type >= ContactListener::IMAccountType) && (type <= ContactListener::EmailAddressType));
-
-    const QSet<quint32> * const typeSet[3] = { &imContacts, &phoneContacts, &emailContacts };
-    return typeSet[type - 1]->contains(localId);
+    if ((types & RecentContactsModel::PhoneNumberRequired) && phoneContacts.contains(localId))
+        return true;
+    if ((types & RecentContactsModel::EmailAddressRequired) && emailContacts.contains(localId))
+        return true;
+    if ((types & RecentContactsModel::AccountUriRequired) && imContacts.contains(localId))
+        return true;
+    return false;
 }
 

--- a/src/eventmodel_p.h
+++ b/src/eventmodel_p.h
@@ -149,7 +149,7 @@ public:
     bool setContactFromCache(CommHistory::Event &event);
     void startContactListening();
 
-    bool contactHasAddressType(ContactListener::ContactAddressType type, quint32 contactId) const;
+    bool contactHasAddress(int types, quint32 contactId) const;
 
     // This is the root node for the internal event tree. In a standard
     // flat model, eventRootNode has rowCount() children with events.

--- a/src/recentcontactsmodel.cpp
+++ b/src/recentcontactsmodel.cpp
@@ -34,10 +34,6 @@ namespace CommHistory {
 
 using namespace CommHistory;
 
-static const QString imAccountType(QString::fromLatin1("accountUri"));
-static const QString phoneNumberType(QString::fromLatin1("phoneNumber"));
-static const QString emailAddressType(QString::fromLatin1("emailAddress"));
-
 static int eventContact(const Event &event)
 {
     return event.contacts().first().first;
@@ -49,7 +45,7 @@ public:
 
     RecentContactsModelPrivate(EventModel *model)
         : EventModelPrivate(model),
-          selectionProperty(ContactListener::UnknownType)
+          requiredProperty(RecentContactsModel::NoPropertyRequired)
     {
         contactChangesEnabled = true;
     }
@@ -76,7 +72,7 @@ private:
 
     bool skipIrrelevantContact(const Event &event);
 
-    ContactListener::ContactAddressType selectionProperty;
+    int requiredProperty;
     mutable QList<Event> pendingEvents;
 };
 
@@ -384,9 +380,9 @@ void RecentContactsModelPrivate::prependEvents(const QList<Event> &events)
 
 bool RecentContactsModelPrivate::skipIrrelevantContact(const Event &event)
 {
-    if (selectionProperty != ContactListener::UnknownType) {
+    if (requiredProperty != RecentContactsModel::NoPropertyRequired) {
         int contactId = eventContact(event);
-        if (!contactHasAddressType(selectionProperty, contactId)) {
+        if (!contactHasAddress(requiredProperty, contactId)) {
             return true;
         }
     }
@@ -403,35 +399,16 @@ RecentContactsModel::~RecentContactsModel()
 {
 }
 
-QString RecentContactsModel::selectionProperty() const
+int RecentContactsModel::requiredProperty() const
 {
     Q_D(const RecentContactsModel);
-
-    return d->selectionProperty == ContactListener::IMAccountType
-                                ? imAccountType
-                                : (d->selectionProperty == ContactListener::PhoneNumberType
-                                                        ? phoneNumberType
-                                                        : (d->selectionProperty == ContactListener::EmailAddressType
-                                                                                ? emailAddressType
-                                                                                : QString()));
+    return d->requiredProperty;
 }
 
-void RecentContactsModel::setSelectionProperty(const QString &name)
+void RecentContactsModel::setRequiredProperty(int requiredProperty)
 {
     Q_D(RecentContactsModel);
-
-    if (name == imAccountType) {
-        d->selectionProperty = ContactListener::IMAccountType;
-    } else if (name == phoneNumberType) {
-        d->selectionProperty = ContactListener::PhoneNumberType;
-    } else if (name == emailAddressType) {
-        d->selectionProperty = ContactListener::EmailAddressType;
-    } else {
-        d->selectionProperty = ContactListener::UnknownType;
-        if (!name.isEmpty()) {
-            qWarning() << "Unknown selection property type:" << name;
-        }
-    }
+    d->requiredProperty = requiredProperty;
 }
 
 bool RecentContactsModel::resolving() const

--- a/src/recentcontactsmodel.h
+++ b/src/recentcontactsmodel.h
@@ -24,6 +24,7 @@
 
 #include "eventmodel.h"
 #include "libcommhistoryexport.h"
+#include <seasidecache.h>
 
 namespace CommHistory {
 
@@ -39,8 +40,9 @@ class LIBCOMMHISTORY_EXPORT RecentContactsModel : public EventModel
 {
     Q_OBJECT
 
-    Q_PROPERTY(QString selectionProperty READ selectionProperty WRITE setSelectionProperty)
+    Q_PROPERTY(int requiredProperty READ requiredProperty WRITE setRequiredProperty)
     Q_PROPERTY(bool resolving READ resolving NOTIFY resolvingChanged)
+    Q_ENUMS(RequiredPropertyType)
 
 public:
     /*!
@@ -62,26 +64,31 @@ public:
      */
     Q_INVOKABLE bool getEvents();
 
-    /*!
-     * Return the name of the property type that contacts must possess to be included in the model.
-     *
-     * \return Property type name
-     */
-    QString selectionProperty() const;
+    enum RequiredPropertyType {
+        NoPropertyRequired = 0,
+        AccountUriRequired = SeasideCache::FetchAccountUri,
+        PhoneNumberRequired = SeasideCache::FetchPhoneNumber,
+        EmailAddressRequired = SeasideCache::FetchEmailAddress
+    };
 
     /*!
-     * Set the property type that contacts must possess to be included in the model.
+     * Returns the property type(s) that contacts must possess to be included in the model.
      *
-     * Valid values are: [ 'accountUri' - contacts must possess an IM account,
-     *                     'phoneNumber' - contacts must possess a phone number,
-     *                     'emailAddress' - contacts must possess an email address ]
-     *
-     * The property names correspond to the property names by which these attributes
-     * are exposed in 'org.nemomobile.contacts.Person'.
-     *
-     * \param name Property type name
+     * \return Property type mask
      */
-    void setSelectionProperty(const QString &name);
+    int requiredProperty() const;
+
+    /*!
+     * Set the property type(s) that contacts must possess to be included in the model.
+     *
+     * Valid values are a combination of: [
+     *   CommRecentContactsModel.AccountUriRequired - contacts possessing an IM account are included,
+     *   CommRecentContactsModel.PhoneNumberRequired - contacts possessing a phone number are included,
+     *   CommRecentContactsModel.EmailAddressRequired - contacts possessing an email address account are included ]
+     *
+     * \param name Property type mask
+     */
+    void setRequiredProperty(int properties);
 
     /*!
      * Returns true if the model is engaged in resolving contacts, or false if all

--- a/tests/ut_recentcontactsmodel/recentcontactsmodeltest.cpp
+++ b/tests/ut_recentcontactsmodel/recentcontactsmodeltest.cpp
@@ -333,36 +333,43 @@ void RecentContactsModelTest::differentTypes()
     QCOMPARE(e.remoteUid(), alicePhone2);
 }
 
-void RecentContactsModelTest::selectionProperty()
+void RecentContactsModelTest::requiredProperty()
 {
     RecentContactsModel phoneModel;
-    phoneModel.setSelectionProperty(QString::fromLatin1("phoneNumber"));
+    phoneModel.setRequiredProperty(RecentContactsModel::PhoneNumberRequired);
 
     RecentContactsModel imModel;
-    imModel.setSelectionProperty(QString::fromLatin1("accountUri"));
+    imModel.setRequiredProperty(RecentContactsModel::AccountUriRequired);
 
     RecentContactsModel emailModel;
-    emailModel.setSelectionProperty(QString::fromLatin1("emailAddress"));
+    emailModel.setRequiredProperty(RecentContactsModel::EmailAddressRequired);
+
+    RecentContactsModel phoneAndImModel;
+    phoneAndImModel.setRequiredProperty(RecentContactsModel::PhoneNumberRequired | RecentContactsModel::AccountUriRequired);
 
     QVERIFY(phoneModel.getEvents());
     QVERIFY(imModel.getEvents());
     QVERIFY(emailModel.getEvents());
+    QVERIFY(phoneAndImModel.getEvents());
 
     QCOMPARE(phoneModel.rowCount(), 0);
     QCOMPARE(imModel.rowCount(), 0);
     QCOMPARE(emailModel.rowCount(), 0);
+    QCOMPARE(phoneAndImModel.rowCount(), 0);
 
     for (int count = 1; count <= 7; ++count) {
         addEvents(count, count);
         QTRY_COMPARE(phoneModel.resolving(), false);
         QTRY_COMPARE(imModel.resolving(), false);
         QTRY_COMPARE(emailModel.resolving(), false);
+        QTRY_COMPARE(phoneAndImModel.resolving(), false);
     }
 
     // Two contacts have phone numbers, two have IM addresses, none have email
     QCOMPARE(phoneModel.rowCount(), 2);
     QCOMPARE(imModel.rowCount(), 2);
     QCOMPARE(emailModel.rowCount(), 0);
+    QCOMPARE(phoneAndImModel.rowCount(), 3);
 
     Event e;
 
@@ -399,17 +406,21 @@ void RecentContactsModelTest::selectionProperty()
     {
         // Repeat the tests to test filtering on fill
         RecentContactsModel phoneModel;
-        phoneModel.setSelectionProperty(QString::fromLatin1("phoneNumber"));
+        phoneModel.setRequiredProperty(RecentContactsModel::PhoneNumberRequired);
 
         RecentContactsModel imModel;
-        imModel.setSelectionProperty(QString::fromLatin1("accountUri"));
+        imModel.setRequiredProperty(RecentContactsModel::AccountUriRequired);
 
         RecentContactsModel emailModel;
-        emailModel.setSelectionProperty(QString::fromLatin1("emailAddress"));
+        emailModel.setRequiredProperty(RecentContactsModel::EmailAddressRequired);
+
+        RecentContactsModel phoneAndImModel;
+        phoneAndImModel.setRequiredProperty(RecentContactsModel::PhoneNumberRequired | RecentContactsModel::AccountUriRequired);
 
         QVERIFY(phoneModel.getEvents());
         QVERIFY(imModel.getEvents());
         QVERIFY(emailModel.getEvents());
+        QVERIFY(phoneAndImModel.getEvents());
 
         QTRY_COMPARE(phoneModel.resolving(), false);
         QCOMPARE(phoneModel.rowCount(), 2);
@@ -419,6 +430,9 @@ void RecentContactsModelTest::selectionProperty()
 
         QTRY_COMPARE(emailModel.resolving(), false);
         QCOMPARE(emailModel.rowCount(), 0);
+
+        QTRY_COMPARE(phoneAndImModel.resolving(), false);
+        QCOMPARE(phoneAndImModel.rowCount(), 3);
 
         // Results should be indentical
         e = phoneModel.event(phoneModel.index(0, 0));

--- a/tests/ut_recentcontactsmodel/recentcontactsmodeltest.h
+++ b/tests/ut_recentcontactsmodel/recentcontactsmodeltest.h
@@ -16,7 +16,7 @@ private slots:
     void repeated();
     void limitedDynamic();
     void differentTypes();
-    void selectionProperty();
+    void requiredProperty();
     void contactRemoved();
 
     void cleanup();


### PR DESCRIPTION
... string.

So that we can provide a bit mask.

DON'T MERGE YET
