### PR TITLE
[libcommhistory] Fix resolving when nothing is actually resolved

### DIFF
--- a/src/recentcontactsmodel.cpp
+++ b/src/recentcontactsmodel.cpp
@@ -201,7 +201,7 @@ void RecentContactsModelPrivate::slotContactUnknown(const QPair<QString, QString
             }
         }
 
-        if (!unresolved && !pendingEvents.isEmpty()) {
+        if (!unresolved) {
             pendingEventsResolved();
         }
     }


### PR DESCRIPTION
If all events in the recent contact history result in not resolving to a contact, ensure that resolving is still updated to false.
