### PR TITLE
[libcommhistory] Fix CallModel eventDeleted signal with groups

### DIFF
--- a/src/callmodel.cpp
+++ b/src/callmodel.cpp
@@ -1040,7 +1040,8 @@ bool CallModel::deleteEvent( int id )
             // delete event from model (not only from db)
             d->deleteFromModel( id );
             // signal delete in case someone else needs to know it
-            emit d->eventDeleted( id );
+            foreach (const Event &e, deletedEvents)
+                emit d->eventDeleted(e.id());
             emit d->eventsCommitted(deletedEvents, true);
 
             return true;


### PR DESCRIPTION
We should send eventDeleted for all events when deleting a group.

There is still a case where it may accidentally lose an event that should be in the group, but that's a hunt for another day..
