### PR TITLE
[libcommhistory] Remove ContactListener wrappers around qtcontacts-sqlite-extensions

### DIFF
--- a/src/contactlistener.cpp
+++ b/src/contactlistener.cpp
@@ -45,21 +45,6 @@ Q_GLOBAL_STATIC(QWeakPointer<ContactListener>, contactListenerInstance);
 
 typedef QPair<QString, QString> StringPair;
 
-int ContactListener::internalContactId(const ApiContactIdType &id)
-{
-    return QtContactsSqliteExtensions::internalContactId(id);
-}
-
-int ContactListener::internalContactId(const QContact &contact)
-{
-    return QtContactsSqliteExtensions::internalContactId(contact.id());
-}
-
-ContactListener::ApiContactIdType ContactListener::apiContactId(int id)
-{
-    return QtContactsSqliteExtensions::apiContactId(static_cast<quint32>(id));
-}
-
 ContactListener::ContactListener(QObject *parent)
     : QObject(parent),
       d_ptr(new ContactListenerPrivate(this))

--- a/src/contactlistener.h
+++ b/src/contactlistener.h
@@ -32,17 +32,6 @@
 
 #include "libcommhistoryexport.h"
 
-// contacts
-#include <QContact>
-#include <QContactId>
-#include "qtcontacts-extensions.h"
-
-#ifdef USING_QTPIM
-QTCONTACTS_USE_NAMESPACE
-#else
-QTM_USE_NAMESPACE
-#endif
-
 namespace CommHistory {
 
 class ContactListenerPrivate;
@@ -53,8 +42,6 @@ class LIBCOMMHISTORY_EXPORT ContactListener : public QObject
     Q_DECLARE_PRIVATE(ContactListener)
 
 public:
-    typedef QtContactsSqliteExtensions::ApiContactIdType ApiContactIdType;
-
     enum ContactAddressType {
         UnknownType = 0,
         IMAccountType,
@@ -82,10 +69,6 @@ public:
     static bool addressMatchesList(const QString &localUid,
                                    const QString &remoteUid,
                                    const QList<ContactAddress> &contactAddresses);
-
-    static int internalContactId(const ApiContactIdType &id);
-    static int internalContactId(const QContact &contact);
-    static ApiContactIdType apiContactId(int internalId);
 
     /**
      * Find a contact for (localUid, remoteUid), result provided via conactUpdate() signal.

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -59,6 +59,8 @@ QTCONTACTS_USE_NAMESPACE
 QTM_USE_NAMESPACE
 #endif
 
+using namespace QtContactsSqliteExtensions;
+
 namespace {
 static int contactNumber = 0;
 
@@ -94,7 +96,7 @@ const char* msgWords[] = { "lorem","ipsum","dolor","sit","amet","consectetur",
 int ticks = 0;
 int idleTicks = 0;
 
-QSet<ContactListener::ApiContactIdType> addedContactIds;
+QSet<ApiContactIdType> addedContactIds;
 QSet<int> addedEventIds;
 
 int addTestEvent(EventModel &model,
@@ -228,20 +230,20 @@ int addTestContact(const QString &name, const QString &remoteUid, const QString 
     filter.setRelationshipType(QContactRelationship::Aggregates);
 #endif
 
-    foreach (const ContactListener::ApiContactIdType &id, manager()->contactIds(filter)) {
+    foreach (const ApiContactIdType &id, manager()->contactIds(filter)) {
         qDebug() << "********** contact id" << id;
         addedContactIds.insert(id);
-        return ContactListener::internalContactId(id);
+        return internalContactId(id);
     }
 
     qWarning() << "Could not find aggregator";
-    return ContactListener::internalContactId(contact);
+    return internalContactId(contact.id());
 }
 
 bool addTestContactAddress(int contactId, const QString &remoteUid, const QString &localUid)
 {
-    QContact existing = manager()->contact(ContactListener::apiContactId(contactId));
-    if (ContactListener::internalContactId(existing) != contactId) {
+    QContact existing = manager()->contact(apiContactId(contactId));
+    if (internalContactId(existing.id()) != (unsigned)contactId) {
         qWarning() << "Could not retrieve contact:" << contactId;
         return false;
     }
@@ -290,7 +292,7 @@ void modifyTestContact(int id, const QString &name)
 {
     qDebug() << Q_FUNC_INFO << id << name;
 
-    QContact contact = manager()->contact(ContactListener::apiContactId(id));
+    QContact contact = manager()->contact(apiContactId(id));
     if (!contact.isEmpty()) {
         qWarning() << "unable to retrieve contact:" << id;
         return;
@@ -311,10 +313,10 @@ void modifyTestContact(int id, const QString &name)
 
 void deleteTestContact(int id)
 {
-    if (!manager()->removeContact(ContactListener::apiContactId(id))) {
+    if (!manager()->removeContact(apiContactId(id))) {
         qWarning() << "error deleting contact:" << id;
     }
-    addedContactIds.remove(ContactListener::apiContactId(id));
+    addedContactIds.remove(apiContactId(id));
 }
 
 void cleanUpTestContacts()
@@ -328,11 +330,11 @@ void cleanUpTestContacts()
 
         foreach (const QContactRelationship &rel, manager()->relationships(aggregatesType)) {
 #ifdef USING_QTPIM
-            ContactListener::ApiContactIdType firstId = rel.first().id();
-            ContactListener::ApiContactIdType secondId = rel.second().id();
+            ApiContactIdType firstId = rel.first().id();
+            ApiContactIdType secondId = rel.second().id();
 #else
-            ContactListener::ApiContactIdType firstId = rel.first().localId();
-            ContactListener::ApiContactIdType secondId = rel.second().localId();
+            ApiContactIdType firstId = rel.first().localId();
+            ApiContactIdType secondId = rel.second().localId();
 #endif
             if (addedContactIds.contains(firstId)) {
                 addedContactIds.insert(secondId);


### PR DESCRIPTION
This was only used internally, and creates problematic header
dependencies for external users of ContactListener. It offers nothing
over the actual API it's wrapping anymore.
