### PR TITLE
[libcommhistory] Fix CallModel insertion in grouped mode

### DIFF
--- a/src/callmodel.cpp
+++ b/src/callmodel.cpp
@@ -536,7 +536,11 @@ void CallModelPrivate::addToModel( Event &event )
                 // no match, insert new row at top
                 emit q->beginInsertRows(QModelIndex(), 0, 0);
                 event.setEventCount(1);
-                eventRootItem->prependChild(new EventTreeItem(event));
+
+                EventTreeItem *newParent = new EventTreeItem(event);
+                newParent->appendChild(new EventTreeItem(event, newParent));
+                eventRootItem->prependChild(newParent);
+
                 emit q->endInsertRows();
             }
 


### PR DESCRIPTION
A CallModel group should always have children; if there is only one
event in the group, the parent node contains one child with the same
event.

This looked correct, but caused deletion to break, because the parent
isn't considered when deleting a group from the model.
