### PR TITLE
[libcommhistory] Increase the maximum digits used in minimized phone num...

### DIFF
--- a/rpm/libcommhistory-qt5.spec
+++ b/rpm/libcommhistory-qt5.spec
@@ -12,7 +12,7 @@ BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Test)
-BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions) >= 0.1.8
+BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions) >= 0.1.27
 BuildRequires:  pkgconfig(contactcache-qt5) >= 0.0.17
 
 %description

--- a/rpm/libcommhistory.spec
+++ b/rpm/libcommhistory.spec
@@ -10,7 +10,7 @@ BuildRequires:  pkgconfig(QtCore) >= 4.7.0
 BuildRequires:  pkgconfig(QtContacts)
 BuildRequires:  pkgconfig(QtDeclarative)
 BuildRequires:  pkgconfig(QJson)
-BuildRequires:  pkgconfig(qtcontacts-sqlite-extensions) >= 0.1.8
+BuildRequires:  pkgconfig(qtcontacts-sqlite-extensions) >= 0.1.27
 BuildRequires:  pkgconfig(contactcache) >= 0.0.17
 
 %description

--- a/src/commonutils.cpp
+++ b/src/commonutils.cpp
@@ -31,23 +31,10 @@
 
 namespace {
 
-const int DEFAULT_PHONE_NUMBER_MATCH_LENGTH = 7;
-int numberMatchLength = 0;
-
 int phoneNumberMatchLength()
 {
-    if (!numberMatchLength) {
-        QSettings settings(QSettings::IniFormat, QSettings::UserScope,
-                           QLatin1String("Nokia"), QLatin1String("Contacts"));
-        bool valid;
-        int length = settings.value(QLatin1String("numberMatchLength")).toInt(&valid);
-
-        if (valid && length)
-            numberMatchLength = length;
-        else
-            numberMatchLength = DEFAULT_PHONE_NUMBER_MATCH_LENGTH;
-    }
-
+    // TODO: use a configuration variable to make this configurable
+    static int numberMatchLength = QtContactsSqliteExtensions::DefaultMaximumPhoneNumberCharacters;
     return numberMatchLength;
 }
 


### PR DESCRIPTION
...bers

Although 7 digits is typically enough to differentiate phone numbers
in their local forms, an eighth digit is sometimes required to
differentiate between a local number and the voicemail service for
that number.

Also, remove the check to see if the maximum value is overridden by
user configuration file.  This could lead to confusing discrepancies
between commhistory and contact number resolution, and should eventually
be replaced by a system-wide configuration setting.
