### PR TITLE
[libcommhistory] Fix DatabaseIO::getEventBy*()

### DIFF
--- a/src/databaseio.cpp
+++ b/src/databaseio.cpp
@@ -465,11 +465,14 @@ bool DatabaseIO::getEventByMessageToken(const QString &token, Event &event)
     }
 
     Event e;
+    bool re = true;
     if (query.next())
         d->readEventResult(query, e);
+    else
+        re = false;
 
     event = e;
-    return true;
+    return re;
 }
 
 bool DatabaseIO::getEventByMmsId(const QString &mmsId, int groupId, Event &event)
@@ -489,11 +492,14 @@ bool DatabaseIO::getEventByMmsId(const QString &mmsId, int groupId, Event &event
     }
 
     Event e;
+    bool re = true;
     if (query.next())
         d->readEventResult(query, e);
+    else
+        re = false;
 
     event = e;
-    return true;
+    return re;
 }
 
 bool DatabaseIO::modifyEvent(Event &event)


### PR DESCRIPTION
Detected by commhistory-daemon's ut_messagereviver.

Compare this change with DatabaseIO::getEvent() which has been fixed
with 5169661 (Use a basic query builder for event/group properties) and
similar change made to DatabaseIO::getGroup() with 4d658fe (Fix issues
uncovered by ut_eventmodel).
