### PR TITLE
[libcommhistory] Use hide_symbols instead of manual cflags

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -55,7 +55,7 @@ equals(QT_MAJOR_VERSION, 5) {
 }
 
 DEFINES += LIBCOMMHISTORY_SHARED
-QMAKE_CXXFLAGS += -fvisibility=hidden
+CONFIG += hide_symbols
 
 # -----------------------------------------------------------------------------
 # input


### PR DESCRIPTION
Found in an old local branch. Builds and runs fine.
