### PR TITLE
[libcommhistory] Add extraProperties API to Event

### DIFF
--- a/src/databaseio.h
+++ b/src/databaseio.h
@@ -107,6 +107,14 @@ public:
     bool getEventByMmsId(const QString &mmsId, int groupId, Event &event);
 
     /*!
+     * Get extra property fields for an event.
+     *
+     * \param event Event instance to query and update with extra properties
+     * \return true if successful, otherwise false
+     */
+    bool getEventExtraProperties(Event &event);
+
+    /*!
      * Modifye an event.
      *
      * \param event Existing event.

--- a/src/databaseio_p.h
+++ b/src/databaseio_p.h
@@ -61,7 +61,7 @@ public:
 
     static QString makeCallGroupURI(const CommHistory::Event &event);
 
-    static void readEventResult(QSqlQuery &query, Event &event);
+    static void readEventResult(QSqlQuery &query, Event &event, bool &hasExtraProperties);
     static void readGroupResult(QSqlQuery &query, Group &group);
 
     static QString eventQueryBase();
@@ -72,6 +72,8 @@ public:
     bool isLastMmsEvent(const QString& messageToken);
 
     bool deleteEmptyGroups();
+
+    bool insertEventProperties(int eventId, const QVariantMap &properties);
 
     QSqlQuery createQuery();
     QSqlDatabase& connection();

--- a/src/event.h
+++ b/src/event.h
@@ -149,6 +149,7 @@ public:
         Contacts,
         IsAction,
         Headers,
+        ExtraProperties,
         //
         NumProperties
     };
@@ -214,6 +215,11 @@ public:
      * \param properties New set of properties.
      */
     void resetModifiedProperties();
+
+    QVariantMap extraProperties() const;
+    void setExtraProperties(const QVariantMap &extraProperties);
+    QVariant extraProperty(const QString &key) const;
+    void setExtraProperty(const QString &key, const QVariant &value);
 
     //\\//\\// G E T - A C C E S S O R S //\\//\\//
     int id() const;

--- a/src/eventmodel_p.cpp
+++ b/src/eventmodel_p.cpp
@@ -138,11 +138,19 @@ bool EventModelPrivate::executeQuery(QSqlQuery &query)
     }
 
     QList<Event> events;
+    QList<int> extraPropertyIndicies;
     while (query.next()) {
         Event e;
-        DatabaseIOPrivate::readEventResult(query, e);
+        bool extra = false;
+        DatabaseIOPrivate::readEventResult(query, e, extra);
+        if (extra)
+            extraPropertyIndicies.append(events.size());
         events.append(e);
     }
+    query.finish();
+
+    foreach (int i, extraPropertyIndicies)
+        DatabaseIO::instance()->getEventExtraProperties(events[i]);
 
     eventsReceivedSlot(0, events.size(), events);
     return true;

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -396,6 +396,8 @@ void Group::setLastModified(const QDateTime &modified)
     d->propertyChanged(Group::LastModified);
 }
 
+// DO NOT change this format; it is not in any way backwards compatible and will break backups
+// To be replaced.
 QDBusArgument &operator<<(QDBusArgument &argument, const Group &group)
 {
     argument.beginStructure();

--- a/tests/ut_eventmodel/eventmodeltest.h
+++ b/tests/ut_eventmodel/eventmodeltest.h
@@ -53,6 +53,7 @@ private slots:
     void testStreaming_data();
     void testStreaming();
     void testModifyInGroup();
+    void testExtraProperties();
     void testMessagePartsQuery_data();
     void testMessagePartsQuery();
     void testContactMatching_data();


### PR DESCRIPTION
```
Extra properties are arbitrary key/value properties that can be attached
to an event. They're intended to be used for temporary or uncommon
values attached to an event, since they are more expensive to query. The
immediate use case is certain MMS-related properties, and it will also
replace some of the less commonly used properties of Event.

A database flag is used to avoid the query overhead when no extra
properties exist on an event.
```

This also adds AutoSavepoint as a database utility class. It creates a database savepoint and rolls back automatically when uncommitted on destruction. Unlike transactions, savepoints can be nested (even inside normal transactions). The top-level savepoint behaves in the same way as a BEGIN/COMMIT transaction.
