### PR TITLE
[libcommhistory] Provide populated property in CallProxyModel

### DIFF
--- a/declarative/src/callproxymodel.cpp
+++ b/declarative/src/callproxymodel.cpp
@@ -5,7 +5,8 @@ CallProxyModel::CallProxyModel(QObject *parent) :
     QSortFilterProxyModel(parent),
     m_source(new CommHistory::CallModel(CommHistory::CallModel::SortByTime, this)),
     m_grouping(GroupByNone),
-    m_componentComplete(false)
+    m_componentComplete(false),
+    m_populated(false)
 {
     m_source->setQueryMode(CommHistory::EventModel::AsyncQuery);
 
@@ -15,6 +16,7 @@ CallProxyModel::CallProxyModel(QObject *parent) :
     connect(this, SIGNAL(rowsInserted(const QModelIndex&,int,int)), this, SIGNAL(countChanged()));
     connect(this, SIGNAL(rowsRemoved(const QModelIndex&,int,int)), this, SIGNAL(countChanged()));
     connect(this, SIGNAL(modelReset()), this, SIGNAL(countChanged()));
+    connect(m_source, SIGNAL(modelReady(bool)), this, SLOT(modelReady(bool)));
 }
 
 void CallProxyModel::classBegin()
@@ -92,3 +94,17 @@ bool CallProxyModel::markAllRead()
 {
     return m_source->markAllRead();
 }
+
+bool CallProxyModel::populated() const
+{
+    return m_populated;
+}
+
+void CallProxyModel::modelReady(bool ready)
+{
+    if (ready) {
+        m_populated = true;
+        emit populatedChanged();
+    }
+}
+

--- a/declarative/src/callproxymodel.h
+++ b/declarative/src/callproxymodel.h
@@ -49,6 +49,7 @@ class CallProxyModel : public QSortFilterProxyModel, public QQmlParserStatus
     Q_PROPERTY(GroupBy groupBy READ groupBy WRITE setGroupBy NOTIFY groupByChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
     Q_PROPERTY(bool resolveContacts READ resolveContacts WRITE setResolveContacts NOTIFY resolveContactsChanged)
+    Q_PROPERTY(bool populated READ populated NOTIFY populatedChanged)
 
 public:
     enum EventRole {
@@ -132,6 +133,7 @@ public:
     bool resolveContacts() const;
     void setResolveContacts(bool enabled);
 
+    bool populated() const;
 public Q_SLOTS:
     void getEvents();
     void setSortRole(int role);
@@ -141,15 +143,19 @@ public Q_SLOTS:
 
     bool markAllRead();
 
+private slots:
+    void modelReady(bool ready);
 Q_SIGNALS:
     void groupByChanged();
     void countChanged();
     void resolveContactsChanged();
+    void populatedChanged();
 
 private:
     CommHistory::CallModel *m_source;
     GroupBy m_grouping;
     bool m_componentComplete;
+    bool m_populated;
 };
 
 #endif // CALLPROXYMODEL_H


### PR DESCRIPTION
Needed to tell the view when the loading has been finished,
whether the model is empty because it hasn't yet been
loaded yet or because it is infact empty.
