### PR TITLE
[libcommhistory] Use localUid to determine when remote UIDs are phone numbers

### DIFF
--- a/src/callmodel.cpp
+++ b/src/callmodel.cpp
@@ -212,15 +212,15 @@ void CallModelPrivate::modelUpdatedSlot( bool successful )
 bool CallModelPrivate::belongToSameGroup( const Event &e1, const Event &e2 )
 {
     if (sortBy == CallModel::SortByContact
-        && remoteAddressMatch(e1.remoteUid(), e2.remoteUid())
         && e1.localUid() == e2.localUid()
+        && remoteAddressMatch(e1.localUid(), e1.remoteUid(), e2.remoteUid())
         && e1.isVideoCall() == e2.isVideoCall())
     {
         return true;
     }
     else if ((sortBy == CallModel::SortByTime || sortBy == CallModel::SortByContactAndType)
-             && (remoteAddressMatch(e1.remoteUid(), e2.remoteUid())
-                 && e1.localUid() == e2.localUid()
+             && (e1.localUid() == e2.localUid()
+                 && remoteAddressMatch(e1.localUid(), e1.remoteUid(), e2.remoteUid())
                  && e1.direction() == e2.direction()
                  && e1.isMissedCall() == e2.isMissedCall()
                  && e1.isVideoCall() == e2.isVideoCall()))
@@ -539,8 +539,8 @@ void CallModelPrivate::insertEvent(Event event)
             // reset event count if type doesn't match top event
             if (!eventMatchesFilter(event) && eventRootItem->childCount()) {
                 EventTreeItem *topItem = eventRootItem->child(0);
-                if (remoteAddressMatch(topItem->event().remoteUid(), event.remoteUid())
-                    && topItem->event().localUid() == event.localUid()) {
+                if (topItem->event().localUid() == event.localUid()
+                    && remoteAddressMatch(event.localUid(), topItem->event().remoteUid(), event.remoteUid())) {
                     EventTreeItem *newTopItem = new EventTreeItem(topItem->event());
                     newTopItem->event().setEventCount(1);
 

--- a/src/commonutils.h
+++ b/src/commonutils.h
@@ -28,13 +28,25 @@
 namespace CommHistory {
 
 /*!
+ * Whether the given localUid needs phone number comparsions
+ *
+ * \param localUid Local UID
+ * \return true if remote UIDs will be compared as phone numbers
+ */
+bool localUidComparesPhoneNumbers(const QString &localUid);
+
+/*!
  * Validates and normalizes a phone number by removing extra characters:
  * "+358 012 (34) 567#3333" -> "+35801234567#3333"
  *
+ * Do not use this function to determine whether an input is a phone
+ * number; that decision should be made based on localUid.
+ *
  * \param number Phone number.
- * \return normalized number, or empty string if invalid.
+ * \param validate Validate phone number (returns empty if invalid)
+ * \return normalized number, or empty string if validating and invalid.
  */
-QString normalizePhoneNumber(const QString &number);
+QString normalizePhoneNumber(const QString &number, bool validate);
 
 /*!
  * Get the last digits of a phone number for comparison purposes.
@@ -48,13 +60,14 @@ QString minimizePhoneNumber(const QString &number);
  * Compares the two remote ids. In case of phone numbers, last digits
  * are compared.
  *
+ * \param localUid Local UID to determine comparison type
  * \param uid First remote id.
  * \param match Second remote id.
  * \param minimizedComparison Compare numbers in minimized form.
  * \return true if addresses match.
  */
-bool remoteAddressMatch(const QString &uid, const QString &match, bool minimizedComparison = false);
-bool remoteAddressMatch(const QStringList &uids, const QStringList &match, bool minimizedComparison = false);
+bool remoteAddressMatch(const QString &localUid, const QString &uid, const QString &match, bool minimizedComparison = false);
+bool remoteAddressMatch(const QString &localUid, const QStringList &uids, const QStringList &match, bool minimizedComparison = false);
 
 }
 

--- a/src/contactgroup.cpp
+++ b/src/contactgroup.cpp
@@ -361,7 +361,7 @@ GroupObject *ContactGroup::findGroup(const QString &localUid, const QStringList 
 
     foreach (GroupObject *g, d->groups) {
         if (g->localUid() == localUid && g->remoteUids().size() == remoteUids.size()
-                && CommHistory::remoteAddressMatch(g->remoteUids(), remoteUids))
+                && CommHistory::remoteAddressMatch(localUid, g->remoteUids(), remoteUids))
             return g;
     }
 

--- a/src/contactgroupmodel.cpp
+++ b/src/contactgroupmodel.cpp
@@ -114,23 +114,17 @@ int ContactGroupModelPrivate::indexForContacts(GroupObject *group)
             if (groups[0]->remoteUids().size() == 1 && items[i]->contactIds().value(0) == contactId)
                 return i;
         }
-    } else if (group->remoteUids().size() == 1) {
+    } else if (group->remoteUids().size() == 1 && localUidComparesPhoneNumbers(group->localUid())) {
         // Use the minimized form of phone numbers to combine groups for unresolved contacts
         // This is important because responses to a SMS may come from a number formatted slightly
         // differently.
-        QString phone = CommHistory::normalizePhoneNumber(group->remoteUids()[0]);
-        if (phone.isEmpty())
-            return -1;
-        phone = minimizePhoneNumber(phone);
-
         for (int i = 0; i < items.size(); i++) {
             QList<GroupObject*> groups = items[i]->groups();
             // Ignore any group with contact matches
-            if (!groups[0]->contactIds().isEmpty() || groups[0]->remoteUids().size() > 1)
+            if (!groups[0]->contactIds().isEmpty() || groups[0]->remoteUids().size() > 1 || groups[0]->localUid() != group->localUid())
                 continue;
 
-            QString match = CommHistory::minimizePhoneNumber(groups[0]->remoteUids()[0]);
-            if (phone == match)
+            if (remoteAddressMatch(group->localUid(), group->remoteUids()[0], groups[0]->remoteUids()[0], true))
                 return i;
         }
     }

--- a/src/contactlistener.cpp
+++ b/src/contactlistener.cpp
@@ -90,8 +90,9 @@ bool ContactListener::addressMatchesList(const QString &localUid,
     QListIterator<StringPair> i(contactAddresses);
     while (i.hasNext()) {
         StringPair address = i.next();
-        if ((address.first.isEmpty() || address.first == localUid)
-            && CommHistory::remoteAddressMatch(remoteUid, address.second, true)) {
+        // Empty address.first is allowed to match phone number type localUids
+        if ((address.first == localUid || (address.first.isEmpty() && localUidComparesPhoneNumbers(localUid)))
+            && CommHistory::remoteAddressMatch(localUid, remoteUid, address.second, true)) {
             return true;
         }
     }
@@ -106,8 +107,8 @@ bool ContactListener::addressMatchesList(const QString &localUid,
     QListIterator<ContactAddress> i(contactAddresses);
     while (i.hasNext()) {
         ContactAddress address = i.next();
-        if ((address.localUid.isEmpty() || address.localUid == localUid)
-            && CommHistory::remoteAddressMatch(remoteUid, address.remoteUid, true)) {
+        if ((address.localUid == localUid || (address.localUid.isEmpty() && localUidComparesPhoneNumbers(localUid)))
+            && CommHistory::remoteAddressMatch(localUid, remoteUid, address.remoteUid, true)) {
             return true;
         }
     }
@@ -125,9 +126,7 @@ void ContactListener::resolveContact(const QString &localUid,
 
     SeasideCache::CacheItem *item = 0;
 
-    // TODO: maybe better to switch on localUid value rather than numeric quality?
-    QString number = CommHistory::normalizePhoneNumber(remoteUid);
-    if (!number.isEmpty()) {
+    if (CommHistory::localUidComparesPhoneNumbers(localUid)) {
         d->m_pending.insert(qMakePair(QString(), remoteUid), input);
         item = SeasideCache::resolvePhoneNumber(d, remoteUid, true);
     } else {

--- a/src/databaseio.cpp
+++ b/src/databaseio.cpp
@@ -1200,12 +1200,11 @@ bool DatabaseIO::rollback()
 QString DatabaseIOPrivate::makeCallGroupURI(const CommHistory::Event &event)
 {
     QString callGroupRemoteId;
-    QString number = normalizePhoneNumber(event.remoteUid());
-    if (number.isEmpty()) {
-        callGroupRemoteId = event.remoteUid();
-    } else {
+    if (localUidComparesPhoneNumbers(event.localUid())) {
         // keep dial string in group uris for separate history entries
         callGroupRemoteId = minimizePhoneNumber(event.remoteUid());
+    } else {
+        callGroupRemoteId = event.remoteUid();
     }
 
     QString videoSuffix;

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -169,7 +169,7 @@ int addTestContact(const QString &name, const QString &remoteUid, const QString 
         return -1;
     }
 
-    if (!localUid.isEmpty() && localUid.indexOf("/ring/tel/") == -1) {
+    if (!localUidComparesPhoneNumbers(localUid)) {
         // Create a metadata detail to link the contact with the account
         QContactOriginMetadata metadata;
         metadata.setGroupId(localUid);
@@ -179,10 +179,7 @@ int addTestContact(const QString &name, const QString &remoteUid, const QString 
             qWarning() << "Unable to add metadata to contact:" << contactUri;
             return false;
         }
-    }
 
-    QString normal = CommHistory::normalizePhoneNumber(remoteUid);
-    if (normal.isEmpty()) {
         QContactOnlineAccount qcoa;
         qcoa.setValue(QContactOnlineAccount__FieldAccountPath, localUid);
         qcoa.setAccountUri(remoteUid);
@@ -236,7 +233,7 @@ bool addTestContactAddress(int contactId, const QString &remoteUid, const QStrin
         return false;
     }
 
-    if (!localUid.isEmpty() && localUid.indexOf("/ring/tel/") == -1) {
+    if (!localUidComparesPhoneNumbers(localUid)) {
         QContactOriginMetadata metadata = existing.detail<QContactOriginMetadata>();
         if (metadata.groupId().isEmpty()) {
             // Create a metadata detail to link the contact with the account
@@ -248,10 +245,7 @@ bool addTestContactAddress(int contactId, const QString &remoteUid, const QStrin
                 return false;
             }
         }
-    }
 
-    QString normal = CommHistory::normalizePhoneNumber(remoteUid);
-    if (normal.isEmpty()) {
         QContactOnlineAccount qcoa;
         qcoa.setValue(QContactOnlineAccount__FieldAccountPath, localUid);
         qcoa.setAccountUri(remoteUid);


### PR DESCRIPTION
Previously, a remoteUid was compared as a phone number (i.e. normalized
and minimized) if it passed validation as a phone number. That logic was
inconsistent with contact resolution and flawed for some
weirdly-formatted numbers, leading in the worst case to hung contact
resolve tasks.

Instead, use the localUid to determine whether remote UIDs are compared
as phone numbers, and normalize them without validation.

This involves API changes to several utility functions, but commhistory
does not currently promise any API stability.
