### PR TITLE
[libcommhistory] Ignore contact accounts without localUid field for resolution

### DIFF
--- a/src/contactlistener_p.h
+++ b/src/contactlistener_p.h
@@ -62,6 +62,7 @@ Q_SIGNALS:
     void contactAlreadyInCache(quint32 localId,
                                const QString &contactName,
                                const QList<ContactAddress> &contactAddresses);
+    void contactAlreadyUnknown(const QPair<QString,QString> &address);
 
 protected:
     void addressResolved(const QString &first, const QString &second, SeasideCache::CacheItem *item);


### PR DESCRIPTION
Valid accounts must have a localUid, and the empty field can be confused
with the syntax used for phone numbers, which leads to bad comparisons.
