### PR TITLE
[libcommhistory] Apply CallModel filters when in tree mode

### DIFF
--- a/src/callmodel.cpp
+++ b/src/callmodel.cpp
@@ -105,7 +105,7 @@ bool CallModelPrivate::eventMatchesFilter( const Event &event ) const
 bool CallModelPrivate::acceptsEvent( const Event &event ) const
 {
     DEBUG() << __PRETTY_FUNCTION__ << event.id();
-    if ( event.type() != Event::CallEvent || (!isInTreeMode && !eventMatchesFilter(event) ))
+    if ( event.type() != Event::CallEvent || !eventMatchesFilter(event) )
     {
         return false;
     }
@@ -869,17 +869,16 @@ bool CallModel::getEvents()
     QString q = DatabaseIOPrivate::eventQueryBase();
     q += QString::fromLatin1("WHERE type=%1 ").arg(Event::CallEvent);
 
-    if (!d->isInTreeMode) {
-        if (d->eventType == CallEvent::ReceivedCallType) {
-            q += QString::fromLatin1("AND direction=%1 AND isMissedCall=0 ").arg(Event::Inbound);
-        } else if (d->eventType == CallEvent::MissedCallType) {
-            q += QString::fromLatin1("AND direction=%1 AND isMissedCall=1 ").arg(Event::Inbound);
-        } else if (d->eventType == CallEvent::DialedCallType) {
-            q += QString::fromLatin1("AND direction=%1 ").arg(Event::Outbound);
-        }
+    if (d->eventType == CallEvent::ReceivedCallType) {
+        q += QString::fromLatin1("AND direction=%1 AND isMissedCall=0 ").arg(Event::Inbound);
+    } else if (d->eventType == CallEvent::MissedCallType) {
+        q += QString::fromLatin1("AND direction=%1 AND isMissedCall=1 ").arg(Event::Inbound);
+    } else if (d->eventType == CallEvent::DialedCallType) {
+        q += QString::fromLatin1("AND direction=%1 ").arg(Event::Outbound);
+    }
 
-        if (!d->filterLocalUid.isEmpty())
-            q += QString::fromLatin1("AND localUid=:filterLocalUid ");
+    if (!d->filterLocalUid.isEmpty()) {
+        q += QString::fromLatin1("AND localUid=:filterLocalUid ");
     }
 
     if (!d->referenceTime.isNull()) {

--- a/tests/modelwatcher.cpp
+++ b/tests/modelwatcher.cpp
@@ -106,6 +106,8 @@ bool ModelWatcher::isFinished() const
         for (int i = 0; i < 5000 && value < expected; i += 50) \
             QTest::qWait(50); \
     } \
+    if (value != expected) \
+        qWarning() << Q_FUNC_INFO << "Incorrect signal count. Expected:" << expected << "Actual:" << value; \
     re &= value == expected
 
 bool ModelWatcher::waitForCommitted(int count)


### PR DESCRIPTION
The filtering options of CallModel were, unexpectedly, ignored when
treeMode was enabled (which is the default). This led to models
containing unexpected data, in one case resulting in deleting all call
events.
