### PR TITLE
Added Q_INTERFACES macro

### DIFF
--- a/declarative/src/callproxymodel.h
+++ b/declarative/src/callproxymodel.h
@@ -38,6 +38,7 @@
 class CallProxyModel : public QSortFilterProxyModel, public QQmlParserStatus
 {
     Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
 
     Q_ENUMS(EventRole)
     Q_ENUMS(EventType)


### PR DESCRIPTION
To silence build warning "Class CallProxyModel implements the interface QQmlParserStatus but does not list it in Q_INTERFACES. qobject_cast to QQmlParserStatus will not work!"
