### PR TITLE
[DatabaseIO] Only mark rows as read when they are currently unread.

### DIFF
--- a/src/databaseio.cpp
+++ b/src/databaseio.cpp
@@ -1086,7 +1086,7 @@ bool DatabaseIO::totalEventsInGroup(int groupId, int &totalEvents)
 
 bool DatabaseIO::markAsReadGroup(int groupId)
 {
-    static const char *q = "UPDATE Events SET isRead=1 WHERE groupId=:groupId";
+    static const char *q = "UPDATE Events SET isRead=1 WHERE groupId=:groupId AND isRead=0";
     QSqlQuery query = CommHistoryDatabase::prepare(q, d->connection());
     query.bindValue(":groupId", groupId);
 
@@ -1103,7 +1103,7 @@ bool DatabaseIO::markAsReadGroup(int groupId)
 bool DatabaseIO::markAsRead(const QList<int> &eventIds)
 {
     QByteArray q = "UPDATE Events SET isRead=1 WHERE id IN (";
-    q += joinNumberList(eventIds) + ")";
+    q += joinNumberList(eventIds) + ") AND isRead=0";
 
     QSqlQuery query = CommHistoryDatabase::prepare(q, d->connection());
     if (!query.exec()) {
@@ -1118,7 +1118,7 @@ bool DatabaseIO::markAsRead(const QList<int> &eventIds)
 
 bool DatabaseIO::markAsReadAll(Event::EventType eventType)
 {
-    static const char *q = "UPDATE Events SET isRead=1 WHERE type=:eventType";
+    static const char *q = "UPDATE Events SET isRead=1 WHERE type=:eventType AND isRead=0";
     QSqlQuery query = CommHistoryDatabase::prepare(q, d->connection());
     query.bindValue(":eventType", eventType);
 


### PR DESCRIPTION
There's no sense endlessly marking things as read. This doesn't scale when the
database continues to grow, and has proven slow on some devices.

At least on one such device, the time for updating ~6k rows went from >1s of
system time (and a lot of sluggishness, thanks to btrfs) down to ~40ms.

Reported-by: Andrea Bernabei and.bernabei@gmail.com
Debugged-with: ^
