### PR TITLE
Removed CallProxyModel::getEvents() slot declaration

### DIFF
--- a/declarative/src/callproxymodel.h
+++ b/declarative/src/callproxymodel.h
@@ -132,7 +132,6 @@ public:
 
     bool populated() const;
 public Q_SLOTS:
-    void getEvents();
     void setSortRole(int role);
     void setFilterRole(int role);
 


### PR DESCRIPTION
Its implementation was missing.
