### PR TITLE
Added getter for commhistory database data dir

### DIFF
--- a/src/commhistorydatabase.cpp
+++ b/src/commhistorydatabase.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of libcommhistory.
 **
-** Copyright (C) 2013 Jolla Ltd.
+** Copyright (C) 2013-2014 Jolla Ltd.
 ** Contact: John Brooks <john.brooks@jollamobile.com>
 **
 ** This library is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
 // Appended to GenericDataLocation (or a hardcoded equivalent on Qt4)
 #define COMMHISTORY_DATABASE_DIR "/commhistory/"
 #define COMMHISTORY_DATABASE_NAME "commhistory.db"
+#define COMMHISTORY_DATA_DIR COMMHISTORY_DATABASE_DIR "data/"
 
 static const char *db_setup[] = {
     "PRAGMA temp_store = MEMORY",
@@ -343,3 +344,7 @@ QSqlQuery CommHistoryDatabase::prepare(const char *statement, const QSqlDatabase
     return query;
 }
 
+QString CommHistoryDatabase::dataDir(int id)
+{
+    return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QStringLiteral(COMMHISTORY_DATA_DIR "%1/").arg(id);
+}

--- a/src/commhistorydatabase.h
+++ b/src/commhistorydatabase.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of libcommhistory.
 **
-** Copyright (C) 2013 Jolla Ltd.
+** Copyright (C) 2013-2014 Jolla Ltd.
 ** Contact: John Brooks <john.brooks@jollamobile.com>
 **
 ** This library is free software; you can redistribute it and/or modify it
@@ -24,12 +24,14 @@
 #define COMMHISTORYDATABASE_H
 
 #include <QSqlDatabase>
+#include "libcommhistoryexport.h"
 
 class CommHistoryDatabase
 {
 public:
     static QSqlDatabase open(const QString &databaseName);
     static QSqlQuery prepare(const char *statement, const QSqlDatabase &database);
+    static LIBCOMMHISTORY_EXPORT QString dataDir(int id);
 };
 
 #endif


### PR DESCRIPTION
Now it's hardcoded in commhistoryd which isn't quite right, it should be defined right next to database path etc. The "message part cleaner" component will need to know this directory as well and it won't necessarily be part of commhistoryd.
