### PR TITLE
[libcommhistory] Resolve event ContactGroup startTime to most recent

### DIFF
--- a/src/contactgroup.cpp
+++ b/src/contactgroup.cpp
@@ -117,7 +117,7 @@ void ContactGroupPrivate::update()
         foreach (const Event::Contact &contact, group->contacts())
             contacts[contact.first] = contact.second;
 
-        if (!uStartTime.isValid() || group->startTime() < uStartTime)
+        if (!uStartTime.isValid() || group->startTime() > uStartTime)
             uStartTime = group->startTime();
 
         if (!uEndTime.isValid() || group->endTime() > uEndTime)


### PR DESCRIPTION
A ContactGroup (conversation) with multiple group objects uses startTime
timestamp from group object with OLDEST startTime.
Fix to use most recent startTime.
Otherwise startTime does not match to latestMessage startTime and leads to wrong
conversation (group) startTime on UI.
