### PR TITLE
[libcommhistory] Enable limiting for flat model queries

### DIFF
--- a/src/callmodel.cpp
+++ b/src/callmodel.cpp
@@ -887,6 +887,12 @@ bool CallModel::getEvents()
 
     q += "ORDER BY endTime DESC, id DESC";
 
+    if(!d->isInTreeMode && d->queryLimit > 0) {
+        /* straightforward limiting can be done in flat mode */
+        QString limit = QString::fromLatin1(" LIMIT %1").arg(d->queryLimit);
+        q += limit;
+    }
+
     QSqlQuery query = DatabaseIOPrivate::instance()->createQuery();
     if (!d->filterLocalUid.isEmpty())
         query.bindValue(":filterLocalUid", d->filterLocalUid);


### PR DESCRIPTION
It's easy to limit results for queries for models which aren't using
tree mode, and limiting increases performance when the full history
isn't needed.
