### PR TITLE
Support for sending MMS read reports

### DIFF
--- a/declarative/src/declarativegroupmanager.cpp
+++ b/declarative/src/declarativegroupmanager.cpp
@@ -117,7 +117,7 @@ bool DeclarativeGroupManager::setEventStatus(int eventId, int status)
         return false;
     }
 
-    Event ev = model.event(model.index(0, 0));
+    Event ev = model.event();
     if (ev.status() == status)
         return true;
 

--- a/declarative/src/mmshelper.cpp
+++ b/declarative/src/mmshelper.cpp
@@ -98,7 +98,7 @@ bool MmsHelper::receiveMessage(int id)
     Event event;
     SingleEventModel model;
     if (model.getEventById(id))
-        event = model.event(model.index(0, 0));
+        event = model.event();
 
     if (!event.isValid()) {
         qWarning() << "MmsHelper::receiveMessage called for unknown event id" << id;
@@ -127,7 +127,7 @@ bool MmsHelper::cancel(int id)
     Event event;
     SingleEventModel model;
     if (model.getEventById(id))
-        event = model.event(model.index(0, 0));
+        event = model.event();
 
     if (!event.isValid()) {
         qWarning() << "MmsHelper::cancel called for unknown event id" << id;

--- a/src/mmsreadreportmodel.cpp
+++ b/src/mmsreadreportmodel.cpp
@@ -1,0 +1,135 @@
+/******************************************************************************
+**
+** This file is part of libcommhistory.
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Slava Monich <slava.monich@jolla.com>
+**
+** This library is free software; you can redistribute it and/or modify it
+** under the terms of the GNU Lesser General Public License version 2.1 as
+** published by the Free Software Foundation.
+**
+** This library is distributed in the hope that it will be useful, but
+** WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+** or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+** License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with this library; if not, write to the Free Software Foundation, Inc.,
+** 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+**
+******************************************************************************/
+
+#include "mmsreadreportmodel.h"
+#include "mmsconstants.h"
+#include "commhistorydatabase.h"
+#include "databaseio_p.h"
+#include "eventmodel_p.h"
+
+#include <QSqlDatabase>
+#include <QSqlQuery>
+
+namespace CommHistory {
+
+class MmsReadReportModel::Private {
+public:
+    static QSqlQuery buildGroupQuery(int groupId);
+};
+
+#define QUERY_EVENT_IS_DRAFT     ":isDraft"
+#define QUERY_EVENT_IS_READ      ":isRead"
+#define QUERY_EVENT_TYPE         ":type"
+#define QUERY_EVENT_DIRECTION    ":direction"
+#define QUERY_EVENT_REPORT_READ  ":reportRead"
+#define QUERY_EVENT_PROPERTY_KEY ":propertyKey"
+#define QUERY_EVENT_GROUP_ID     ":groupId"
+
+QSqlQuery MmsReadReportModel::Private::buildGroupQuery(int groupId)
+{
+    QString q(DatabaseIOPrivate::eventQueryBase());
+    q += " WHERE Events.groupId = " QUERY_EVENT_GROUP_ID
+         " AND Events.isDraft = " QUERY_EVENT_IS_DRAFT
+         " AND Events.isRead = " QUERY_EVENT_IS_READ
+         " AND Events.type = " QUERY_EVENT_TYPE
+         " AND Events.direction = " QUERY_EVENT_DIRECTION
+         " AND Events.reportRead = " QUERY_EVENT_REPORT_READ
+         " AND Events.mmsId != '' "
+         " AND Events.id IN ("
+         " SELECT DISTINCT eventId from EventProperties"
+         " WHERE EventProperties.key = " QUERY_EVENT_PROPERTY_KEY " )"
+         " ORDER BY Events.endTime DESC, Events.id DESC";
+
+    QSqlDatabase db(DatabaseIOPrivate::instance()->connection());
+    QSqlQuery query = CommHistoryDatabase::prepare(q.toLatin1(), db);
+    query.bindValue(QUERY_EVENT_GROUP_ID, groupId);
+    query.bindValue(QUERY_EVENT_IS_DRAFT, false);
+    query.bindValue(QUERY_EVENT_IS_READ, true);
+    query.bindValue(QUERY_EVENT_TYPE, Event::MMSEvent);
+    query.bindValue(QUERY_EVENT_DIRECTION, Event::Inbound);
+    query.bindValue(QUERY_EVENT_REPORT_READ, true);
+    query.bindValue(QUERY_EVENT_PROPERTY_KEY, QString(MMS_PROPERTY_IMSI));
+    return query;
+}
+
+bool MmsReadReportModel::acceptsEvent(const Event &event)
+{
+    return (event.type() == Event::MMSEvent &&
+            event.direction() == Event::Inbound &&
+            event.isRead() &&
+            event.reportRead() &&
+            !event.mmsId().isEmpty() &&
+            !event.extraProperty(MMS_PROPERTY_IMSI).toString().isEmpty());
+}
+
+MmsReadReportModel::MmsReadReportModel(QObject *parent) : EventModel(parent), d(NULL)
+{
+    setQueryMode(EventModel::SyncQuery);
+    setResolveContacts(false);
+}
+
+MmsReadReportModel::~MmsReadReportModel()
+{
+}
+
+int MmsReadReportModel::count() const
+{
+    return EventModel::rowCount();
+}
+
+bool MmsReadReportModel::getEvent(int eventId)
+{
+    if (rowCount() > 0) {
+        beginResetModel();
+        d_ptr->clearEvents();
+        endResetModel();
+    }
+
+    if (eventId >= 0) {
+        Event event;
+        if (d_ptr->database()->getEvent(eventId, event)) {
+            QList<Event> events;
+            events.append(event);
+            return d_ptr->fillModel(0, 1, events);
+        }
+    }
+
+    return false;
+}
+
+bool MmsReadReportModel::getEvents(int groupId)
+{
+    if (rowCount() > 0) {
+        beginResetModel();
+        d_ptr->clearEvents();
+        endResetModel();
+    }
+
+    if (groupId >= 0) {
+        QSqlQuery query = Private::buildGroupQuery(groupId);
+        return d_ptr->executeQuery(query);
+    }
+
+    return false;
+}
+
+} // CommHistory

--- a/src/mmsreadreportmodel.h
+++ b/src/mmsreadreportmodel.h
@@ -1,0 +1,71 @@
+/******************************************************************************
+**
+** This file is part of libcommhistory.
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Slava Monich <slava.monich@jolla.com>
+**
+** This library is free software; you can redistribute it and/or modify it
+** under the terms of the GNU Lesser General Public License version 2.1 as
+** published by the Free Software Foundation.
+**
+** This library is distributed in the hope that it will be useful, but
+** WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+** or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+** License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with this library; if not, write to the Free Software Foundation, Inc.,
+** 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+**
+******************************************************************************/
+
+#ifndef COMMHISTORY_MMSREADREPORTMODEL_H
+#define COMMHISTORY_MMSREADREPORTMODEL_H
+
+#include "eventmodel.h"
+
+namespace CommHistory {
+
+/**
+ * Model for accessing events that require read reports for them to be sent.
+ * Initialize with getEvent() or getEvents().
+ */
+class LIBCOMMHISTORY_EXPORT MmsReadReportModel: public EventModel
+{
+    Q_OBJECT
+
+public:
+    MmsReadReportModel(QObject *parent = 0);
+    ~MmsReadReportModel();
+
+    /**
+     * Returns number of events in the model
+     */
+    int count() const;
+
+    /**
+     * Resets model to the specified event. If this event does not require
+     * read report for it to be sent, returns false even if the event with
+     * this id exists in the database.
+     */
+    bool getEvent(int eventId);
+
+    /**
+     * Resets model to events from the specified group.
+     */
+    bool getEvents(int groupId);
+
+    /**
+     * Checks if an external event would have been accepted by the model.
+     */
+    static bool acceptsEvent(const Event &event);
+
+private:
+    class Private;
+    Private* d;
+};
+
+}
+
+#endif // COMMHISTORY_MMSREADREPORTMODEL_H

--- a/src/singleeventmodel.cpp
+++ b/src/singleeventmodel.cpp
@@ -2,8 +2,9 @@
 **
 ** This file is part of libcommhistory.
 **
+** Copyright (C) 2014-2015 Jolla Ltd.
 ** Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
-** Contact: Reto Zingg <reto.zingg@nokia.com>
+** Contact: Reto Zingg <reto.zingg@jolla.com>
 **
 ** This library is free software; you can redistribute it and/or modify it
 ** under the terms of the GNU Lesser General Public License version 2.1 as
@@ -37,7 +38,7 @@ using namespace CommHistory;
 
 class SingleEventModelPrivate : public EventModelPrivate {
 public:
-    Q_DECLARE_PUBLIC(SingleEventModel);
+    Q_DECLARE_PUBLIC(SingleEventModel)
 
     SingleEventModelPrivate(EventModel *model)
         : EventModelPrivate(model) {
@@ -161,5 +162,11 @@ bool SingleEventModel::getEventByTokens(const QString &token,
 
     return d->executeQuery(query);
 }
+
+Event SingleEventModel::event() const
+{
+    return EventModel::event(index(0, 0));
+}
+
 
 } // namespace CommHistory

--- a/src/singleeventmodel.h
+++ b/src/singleeventmodel.h
@@ -2,8 +2,9 @@
 **
 ** This file is part of libcommhistory.
 **
+** Copyright (C) 2014-2015 Jolla Ltd.
 ** Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
-** Contact: Reto Zingg <reto.zingg@nokia.com>
+** Contact: Reto Zingg <reto.zingg@jolla.com>
 **
 ** This library is free software; you can redistribute it and/or modify it
 ** under the terms of the GNU Lesser General Public License version 2.1 as
@@ -74,8 +75,13 @@ public:
                           const QString &mmsId,
                           int groupId);
 
+    /**
+     * Returns the event fetched by one of the above functions.
+     */
+    Event event() const;
+
 private:
-    Q_DECLARE_PRIVATE(SingleEventModel);
+    Q_DECLARE_PRIVATE(SingleEventModel)
 };
 
 } // namespace CommHistory

--- a/src/sources.pri
+++ b/src/sources.pri
@@ -22,6 +22,7 @@ HEADERS += commonutils.h \
            updatesemitter.h \
            constants.h \
            mmsconstants.h \
+           mmsreadreportmodel.h \
            groupobject.h \
            groupmanager.h \
            groupmanager_p.h \
@@ -48,6 +49,7 @@ SOURCES += commonutils.cpp \
            adaptor.cpp \
            event.cpp \
            messagepart.cpp \
+           mmsreadreportmodel.cpp \
            classzerosmsmodel.cpp \
            contactlistener.cpp \
            singleeventmodel.cpp \

--- a/tests/ut_eventmodel/eventmodeltest.cpp
+++ b/tests/ut_eventmodel/eventmodeltest.cpp
@@ -2,8 +2,9 @@
 **
 ** This file is part of libcommhistory.
 **
+** Copyright (C) 2014-2015 Jolla Ltd.
 ** Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
-** Contact: Reto Zingg <reto.zingg@nokia.com>
+** Contact: Reto Zingg <reto.zingg@jolla.com>
 **
 ** This library is free software; you can redistribute it and/or modify it
 ** under the terms of the GNU Lesser General Public License version 2.1 as
@@ -1415,7 +1416,7 @@ void EventModelTest::testExtraProperties()
     // Read property
     SingleEventModel model2;
     QVERIFY(model2.getEventById(newEvent.id()));
-    Event returnedEvent = model2.event(model2.index(0, 0));
+    Event returnedEvent = model2.event();
     QVERIFY(returnedEvent.isValid());
     QCOMPARE(returnedEvent.extraProperties().size(), 1);
     QCOMPARE(returnedEvent.extraProperty("testing").toInt(), 42);
@@ -1429,7 +1430,7 @@ void EventModelTest::testExtraProperties()
 
     // Re-read property
     QVERIFY(model2.getEventById(newEvent.id()));
-    returnedEvent = model2.event(model2.index(0, 0));
+    returnedEvent = model2.event();
     QVERIFY(returnedEvent.isValid());
     QVERIFY(returnedEvent.extraProperties().isEmpty());
 }

--- a/tests/ut_singleeventmodel/singleeventmodeltest.cpp
+++ b/tests/ut_singleeventmodel/singleeventmodeltest.cpp
@@ -58,7 +58,7 @@ void SingleEventModelTest::getEventById()
 
     QCOMPARE(model.rowCount(), 1);
 
-    Event modelEvent = model.event(model.index(0, 0));
+    Event modelEvent = model.event();
     QVERIFY(compareEvents(event, modelEvent));
 }
 
@@ -110,7 +110,7 @@ void SingleEventModelTest::getEventByTokens()
 
     QCOMPARE(model.rowCount(), 1);
 
-    Event modelEvent = model.event(model.index(0, 0));
+    Event modelEvent = model.event();
     QVERIFY(compareEvents(event, modelEvent));
 
     QVERIFY(model.getEventByTokens("messageTokenB1", "", group1.id()));
@@ -118,7 +118,7 @@ void SingleEventModelTest::getEventByTokens()
 
     QCOMPARE(model.rowCount(), 1);
 
-    modelEvent = model.event(model.index(0, 0));
+    modelEvent = model.event();
     QVERIFY(compareEvents(event, modelEvent));
 
     QVERIFY(model.getEventByTokens("messageTokenB1", "", group1.id() + 1));
@@ -132,7 +132,7 @@ void SingleEventModelTest::getEventByTokens()
 
     QCOMPARE(model.rowCount(), 1);
 
-    modelEvent = model.event(model.index(0, 0));
+    modelEvent = model.event();
     QVERIFY(compareEvents(event, modelEvent));
 
     QVERIFY(model.getEventByTokens("", "nonExistingMmsId", group1.id()));
@@ -145,7 +145,7 @@ void SingleEventModelTest::getEventByTokens()
 
     QCOMPARE(model.rowCount(), 1);
 
-    modelEvent = model.event(model.index(0, 0));
+    modelEvent = model.event();
     QVERIFY(compareEvents(mms, modelEvent));
 
     QVERIFY(model.getEventByTokens("", "mmsId", group2.id()));
@@ -153,7 +153,7 @@ void SingleEventModelTest::getEventByTokens()
 
     QCOMPARE(model.rowCount(), 1);
 
-    modelEvent = model.event(model.index(0, 0));
+    modelEvent = model.event();
     QVERIFY(compareEvents(mms2, modelEvent));
 
     QVERIFY(model.getEventByTokens("mmsMessageToken", "mmsId", group1.id()));
@@ -161,7 +161,7 @@ void SingleEventModelTest::getEventByTokens()
 
     QCOMPARE(model.rowCount(), 1);
 
-    modelEvent = model.event(model.index(0, 0));
+    modelEvent = model.event();
     QVERIFY(compareEvents(mms, modelEvent));
 }
 
@@ -202,7 +202,7 @@ void SingleEventModelTest::contactMatching()
 
     QVERIFY(model.getEventById(eventId));
     QVERIFY(watcher.waitForModelReady());
-    Event event = model.event(model.index(0, 0));
+    Event event = model.event();
     QCOMPARE(event.id(), eventId);
     QCOMPARE(event.contactId(), 0);
 
@@ -215,7 +215,7 @@ void SingleEventModelTest::contactMatching()
 
     QVERIFY(model.getEventById(eventId));
     QVERIFY(watcher.waitForModelReady());
-    event = model.event(model.index(0, 0));
+    event = model.event();
     QCOMPARE(event.id(), eventId);
     QCOMPARE(event.contactId(), 0);
 
@@ -223,7 +223,7 @@ void SingleEventModelTest::contactMatching()
 
     QVERIFY(model.getEventById(eventId));
     QVERIFY(watcher.waitForModelReady());
-    event = model.event(model.index(0, 0));
+    event = model.event();
     QCOMPARE(event.id(), eventId);
 
     QCOMPARE(event.contactId(), contactId);
@@ -271,7 +271,7 @@ void SingleEventModelTest::updateStatus()
 
     QCOMPARE(model.rowCount(), 1);
 
-    Event modelEvent = model.event(model.index(0, 0));
+    Event modelEvent = model.event();
 
     QVERIFY(modelEvent.validProperties().contains(CommHistory::Event::Status));
     QVERIFY(modelEvent.validProperties().contains(CommHistory::Event::MessageToken));
@@ -286,7 +286,7 @@ void SingleEventModelTest::updateStatus()
 
     QCOMPARE(observer.rowCount(), 1);
 
-    Event observedEvent = observer.event(observer.index(0, 0));
+    Event observedEvent = observer.event();
 
     QVERIFY(compareEvents(event, observedEvent));
 
@@ -297,7 +297,7 @@ void SingleEventModelTest::updateStatus()
 
     //check observer model
     QTest::qWait(100);
-    observedEvent = observer.event(observer.index(0, 0));
+    observedEvent = observer.event();
 
     QCOMPARE(observedEvent.freeText(), event.freeText());
     QCOMPARE(observedEvent.status(), Event::SentStatus);


### PR DESCRIPTION
Alternative to https://github.com/nemomobile/libcommhistory/pull/107, but doesn't touch the existing `ConversationModel`, introducing new `MmsReadReportModel` instead. This is the third and hopefully the final approach to implementing MMS read reports.