### PR TITLE
[libcommhistory] Include devel dependency via pkgconfig. Fixes MER#1274

### DIFF
--- a/src/commhistory-qt5.pc
+++ b/src/commhistory-qt5.pc
@@ -9,4 +9,4 @@ Version: 1.8.5
 Libs: -L${libdir} -lcommhistory-qt5
 Libs.private: -L/usr/lib
 Cflags:  -I${includedir}
-Requires: Qt5Core
+Requires: Qt5Core contactcache-qt5


### PR DESCRIPTION
Anything that depends on libcommhistory-qt5-devel now also depends on libcontacts-qt5-devel.