### PR TITLE
[libcommhistory] Keep numbers with empty minimization separate. Contributes to MER#1315

### DIFF
--- a/src/contactlistener.cpp
+++ b/src/contactlistener.cpp
@@ -141,10 +141,10 @@ void ContactListenerPrivate::retryFinished()
     retryRecipients.clear();
 }
 
-static bool recipientMatchesDetails(const Recipient &recipient, const QList<Recipient> &addresses, const QList<QPair<QString, quint32> > &phoneNumbers)
+static bool recipientMatchesDetails(const Recipient &recipient, const QList<Recipient> &addresses, const QList<Recipient::PhoneNumberMatchDetails> &phoneNumbers)
 {
     if (recipient.isPhoneNumber()) {
-        for (QList<QPair<QString, quint32> >::const_iterator it = phoneNumbers.begin(), end = phoneNumbers.end(); it != end; ++it) {
+        for (QList<Recipient::PhoneNumberMatchDetails>::const_iterator it = phoneNumbers.begin(), end = phoneNumbers.end(); it != end; ++it) {
             if (recipient.matchesPhoneNumber(*it))
                 return true;
         }
@@ -174,7 +174,7 @@ void ContactListenerPrivate::itemUpdated(SeasideCache::CacheItem *item)
         addresses.append(Recipient(account.value<QString>(QContactOnlineAccount__FieldAccountPath), account.accountUri()));
     }
 
-    QList<QPair<QString, quint32> > phoneNumbers;
+    QList<Recipient::PhoneNumberMatchDetails> phoneNumbers;
     foreach (const QContactPhoneNumber &phoneNumber, item->contact.details<QContactPhoneNumber>()) {
         phoneNumbers.append(Recipient::phoneNumberMatchDetails(phoneNumber.number()));
     }

--- a/src/contactresolver.cpp
+++ b/src/contactresolver.cpp
@@ -178,7 +178,7 @@ void ContactResolverPrivate::addressResolved(const QString &first, const QString
     } else if (first.isEmpty()) {
         // This resolution is for a phone number - we need to call back to libcontacts
         // to select the best match from multiple possible resolutions
-        const QPair<QString, quint32> phoneNumber(Recipient::phoneNumberMatchDetails(second));
+        const Recipient::PhoneNumberMatchDetails phoneNumber(Recipient::phoneNumberMatchDetails(second));
         for (it = pending.begin(); it != pending.end(); ) {
             if (it->matchesPhoneNumber(phoneNumber)) {
                 // Look up the best match for the full number

--- a/src/recipient.h
+++ b/src/recipient.h
@@ -61,6 +61,12 @@ typedef QWeakPointer<RecipientPrivate> WeakRecipient;
 class LIBCOMMHISTORY_EXPORT Recipient
 {
 public:
+    struct PhoneNumberMatchDetails {
+        QString number;
+        QString minimizedNumber;
+        quint32 minimizedNumberHash;
+    };
+
     Recipient();
     Recipient(const QString &localUid, const QString &remoteUid);
     Recipient(const Recipient &o);
@@ -85,7 +91,7 @@ public:
     bool isSameContact(const Recipient &o) const;
 
     bool matchesRemoteUid(const QString &remoteUid) const;
-    bool matchesPhoneNumber(const QPair<QString, quint32> &phoneNumber) const;
+    bool matchesPhoneNumber(const PhoneNumberMatchDetails &phoneNumber) const;
 
     bool matchesAddressFlags(quint64 flags) const;
 
@@ -133,7 +139,7 @@ public:
 
     /* Return the string in the form suitable for testing phone number matches
      */
-    static QPair<QString, quint32> phoneNumberMatchDetails(const QString &s);
+    static PhoneNumberMatchDetails phoneNumberMatchDetails(const QString &s);
 
 private:
     QSharedPointer<RecipientPrivate> d;
@@ -176,7 +182,7 @@ public:
         return false;
     }
 
-    bool matchesPhoneNumber(const QPair<QString, quint32> &phoneNumber) const
+    bool matchesPhoneNumber(const Recipient::PhoneNumberMatchDetails &phoneNumber) const
     {
         for (const_iterator it = constBegin(), end = constEnd(); it != end; ++it)
             if (it->matchesPhoneNumber(phoneNumber))

--- a/tests/ut_callmodel/callmodeltest.h
+++ b/tests/ut_callmodel/callmodeltest.h
@@ -50,6 +50,7 @@ private slots:
     void testMarkAllRead();
     void testModifyEvent();
     void testMinimizedPhone();
+    void testMinimizedEmpty();
     void testContactGrouping();
     void cleanupTestCase();
 


### PR DESCRIPTION
Phone numbers that have a minimized form of empty should not be grouped together unless they match exactly.