### PR TITLE
[libcommhistory] Run unit tests as privileged user. Contributes to MER#1374

### DIFF
--- a/rpm/libcommhistory-qt5.spec
+++ b/rpm/libcommhistory-qt5.spec
@@ -24,6 +24,7 @@ Library for accessing the communications (IM, SMS and call) history database.
 %package unit-tests
 Summary: Unit Test files for libcommhistory
 Group: Development/Libraries
+Requires: blts-tools
 
 %description unit-tests
 Unit Test files for libcommhistory

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -69,6 +69,7 @@ QContactManager *createManager()
     QMap<QString, QString> parameters;
     QString envspec(QStringLiteral("org.nemomobile.contacts.sqlite"));
     parameters.insert(QString::fromLatin1("mergePresenceChanges"), QString::fromLatin1("false"));
+    parameters.insert(QString::fromLatin1("autoTest"), QString::fromLatin1("true"));
     if (!envspec.isEmpty()) {
         qDebug() << "Using contact manager:" << envspec;
         return new QContactManager(envspec, parameters);

--- a/tests/ut_callmodel/test_set.xml
+++ b/tests/ut_callmodel/test_set.xml
@@ -1,5 +1,5 @@
 <set description="@TEST_SUITE_NAME@:ut_callmodel" name="ut_callmodel">
     <case description="@TEST_SUITE_NAME@:ut_callmodel:" name="callmodel" level="Component" type="Functional">
-        <step expected_result="0">/opt/tests/@TEST_SUITE_NAME@/ut_callmodel</step>
+        <step expected_result="0">LIBCONTACTS_TEST_MODE=1 /usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/@TEST_SUITE_NAME@/ut_callmodel' nemo</step>
     </case>
 </set>

--- a/tests/ut_conversationmodel/test_set.xml
+++ b/tests/ut_conversationmodel/test_set.xml
@@ -1,5 +1,5 @@
 <set description="@TEST_SUITE_NAME@:ut_conversationmodel" name="ut_conversationmodel">
     <case description="@TEST_SUITE_NAME@:ut_conversationmodel:" name="conversationmodel" level="Component" type="Functional">
-        <step expected_result="0">/opt/tests/@TEST_SUITE_NAME@/ut_conversationmodel</step>
+        <step expected_result="0">LIBCONTACTS_TEST_MODE=1 /usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/@TEST_SUITE_NAME@/ut_conversationmodel' nemo</step>
     </case>
 </set>

--- a/tests/ut_eventmodel/test_set.xml
+++ b/tests/ut_eventmodel/test_set.xml
@@ -1,5 +1,5 @@
 <set description="@TEST_SUITE_NAME@:ut_eventmodel" name="ut_eventmodel">
     <case description="@TEST_SUITE_NAME@:ut_eventmodel:" name="eventmodel" level="Component" type="Functional" insignificant="true">
-        <step expected_result="0">/opt/tests/@TEST_SUITE_NAME@/ut_eventmodel</step>
+        <step expected_result="0">LIBCONTACTS_TEST_MODE=1 /usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/@TEST_SUITE_NAME@/ut_eventmodel' nemo</step>
     </case>
 </set>

--- a/tests/ut_groupmodel/test_set.xml
+++ b/tests/ut_groupmodel/test_set.xml
@@ -1,5 +1,5 @@
 <set description="@TEST_SUITE_NAME@:ut_groupmodel" name="ut_groupmodel">
     <case description="@TEST_SUITE_NAME@:ut_groupmodel:" name="groupmodel" level="Component" type="Functional" timeout="180">
-        <step expected_result="0">/opt/tests/@TEST_SUITE_NAME@/ut_groupmodel -maxwarnings 10000</step>
+        <step expected_result="0">LIBCONTACTS_TEST_MODE=1 /usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/@TEST_SUITE_NAME@/ut_groupmodel -maxwarnings 10000' nemo</step>
     </case>
 </set>

--- a/tests/ut_recentcontactsmodel/test_set.xml
+++ b/tests/ut_recentcontactsmodel/test_set.xml
@@ -1,5 +1,5 @@
 <set description="@TEST_SUITE_NAME@:ut_recentcontactsmodel" name="ut_recentcontactsmodel">
     <case description="@TEST_SUITE_NAME@:ut_recentcontactsmodel:" name="recentcontactsmodel" level="Component" type="Functional" timeout="180">
-        <step expected_result="0">/opt/tests/@TEST_SUITE_NAME@/ut_recentcontactsmodel</step>
+        <step expected_result="0">LIBCONTACTS_TEST_MODE=1 /usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/@TEST_SUITE_NAME@/ut_recentcontactsmodel' nemo</step>
     </case>
 </set>

--- a/tests/ut_singlecontacteventmodel/test_set.xml
+++ b/tests/ut_singlecontacteventmodel/test_set.xml
@@ -1,5 +1,5 @@
 <set description="@TEST_SUITE_NAME@:ut_singlecontacteventmodel" name="ut_singlecontacteventmodel">
     <case description="@TEST_SUITE_NAME@:ut_singlecontacteventmodel:" name="singlecontacteventmodel" level="Component" type="Functional">
-        <step expected_result="0">/opt/tests/@TEST_SUITE_NAME@/ut_singlecontacteventmodel</step>
+        <step expected_result="0">LIBCONTACTS_TEST_MODE=1 /usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/@TEST_SUITE_NAME@/ut_singlecontacteventmodel' nemo</step>
     </case>
 </set>

--- a/tests/ut_singleeventmodel/test_set.xml
+++ b/tests/ut_singleeventmodel/test_set.xml
@@ -1,5 +1,5 @@
 <set description="@TEST_SUITE_NAME@:ut_singleeventmodel" name="ut_singleeventmodel">
     <case description="@TEST_SUITE_NAME@:ut_singleeventmodel:" name="singleeventmodel" level="Component" type="Functional">
-        <step expected_result="0">/opt/tests/@TEST_SUITE_NAME@/ut_singleeventmodel</step>
+        <step expected_result="0">LIBCONTACTS_TEST_MODE=1 /usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/@TEST_SUITE_NAME@/ut_singleeventmodel' nemo</step>
     </case>
 </set>


### PR DESCRIPTION
Privileged mode is necessary to get predictable behavior from the contacts API. Also prefer to use the contacts database specifically for unit tests rather than the system database.
